### PR TITLE
Fix macOS build with Homebrew OpenCV 4

### DIFF
--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -59,7 +59,7 @@ jobs:
 
           brew update
 
-          checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv openjph openexr
+          checkPkgAndInstall pkg-config glew lz4 libjpeg libpng lzo boost libusb libmypaint ccache jpeg-turbo ninja opencv@4 openjph openexr
 
           brew list --formula | grep '^qt' | grep -v '@5' | xargs -n1 brew unlink || true
 
@@ -95,6 +95,7 @@ jobs:
             -DQT_PATH=$(brew --prefix qt@5)/lib \
             -DQt5_DIR=$(brew --prefix qt@5)/lib/cmake/Qt5 \
             -DCMAKE_PREFIX_PATH=$(brew --prefix qt@5)/lib/cmake/Qt5 \
+            -DOpenCV_DIR=$(brew --prefix opencv@4)/lib/cmake/opencv4 \
             -DWITH_TRANSLATION=OFF
           ninja -j $(sysctl -n hw.ncpu)
       - name: Introduce Libraries and Stuff


### PR DESCRIPTION
## Summary

- install Homebrew's versioned `opencv@4` formula instead of unversioned `opencv`
- point CMake directly to the OpenCV 4 package configuration directory

## Reason

Homebrew's unversioned `opencv` formula now installs OpenCV 5.0.0. OpenToonz requests OpenCV 4.1-compatible configuration, causing the macOS workflow to fail during CMake configuration:

```text
Could not find a configuration file for package "OpenCV" that is compatible
with requested version "4.1".

/usr/local/lib/cmake/opencv5/OpenCVConfig.cmake, version: 5.0.0
```

This PR lets the OAL fork validate the workflow repair before submitting the same focused patch upstream.

Reference: opentoonz/opentoonz Actions run 29386934356