### PR TITLE
Add Ungroup All in Drawing

### DIFF
--- a/stuff/profiles/layouts/rooms/Default/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/Default/menubar_template.xml
@@ -74,6 +74,8 @@
         <menu title="Group">
             <command>MI_Group</command>
             <command>MI_Ungroup</command>
+            <command>MI_UngroupAll</command>
+            <separator/>
             <command>MI_EnterGroup</command>
             <command>MI_ExitGroup</command>
         </menu>

--- a/stuff/profiles/layouts/rooms/Default/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/Default/menubar_template.xml
@@ -74,6 +74,8 @@
         <menu title="Group">
             <command>MI_Group</command>
             <command>MI_Ungroup</command>
+            <command>MI_UngroupAllSelected</command>
+            <separator/>
             <command>MI_UngroupAll</command>
             <separator/>
             <command>MI_EnterGroup</command>

--- a/stuff/profiles/layouts/rooms/StudioGhibli/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/StudioGhibli/menubar_template.xml
@@ -66,6 +66,8 @@
     <separator/>
     <command>MI_Group</command>
     <command>MI_Ungroup</command>
+    <command>MI_UngroupAllSelected</command>
+    <separator/>
     <command>MI_UngroupAll</command>
     <separator/>
     <command>MI_EnterGroup</command>

--- a/stuff/profiles/layouts/rooms/StudioGhibli/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/StudioGhibli/menubar_template.xml
@@ -66,6 +66,8 @@
     <separator/>
     <command>MI_Group</command>
     <command>MI_Ungroup</command>
+    <command>MI_UngroupAll</command>
+    <separator/>
     <command>MI_EnterGroup</command>
     <command>MI_ExitGroup</command>
     <separator/>

--- a/toonz/sources/include/tools/imagegrouping.h
+++ b/toonz/sources/include/tools/imagegrouping.h
@@ -60,6 +60,8 @@ public:
   }
   void group();
   void ungroup();
+  //! Recursively ungroup the selected group(s), preserving any entered outer group.
+  void ungroupSelectedAll();
   //! Remove every explicit group and subgroup from the current vector drawing.
   void ungroupAll();
   void enterGroup();

--- a/toonz/sources/include/tools/imagegrouping.h
+++ b/toonz/sources/include/tools/imagegrouping.h
@@ -23,13 +23,14 @@ class DVAPI TGroupCommand final : public QObject {
   Q_OBJECT
 public:
   enum {
-    NONE     = 0,
-    FRONT    = 1,
-    FORWARD  = 2,
-    BACKWARD = 4,
-    BACK     = 8,
-    GROUP    = 16,
-    UNGROUP  = 32
+    NONE        = 0,
+    FRONT       = 1,
+    FORWARD     = 2,
+    BACKWARD    = 4,
+    BACK        = 8,
+    GROUP       = 16,
+    UNGROUP     = 32,
+    UNGROUP_ALL = 64
   };
 
   StrokeSelection *m_sel;
@@ -59,6 +60,8 @@ public:
   }
   void group();
   void ungroup();
+  //! Remove every explicit group and subgroup from the current vector drawing.
+  void ungroupAll();
   void enterGroup();
   void exitGroup();
 

--- a/toonz/sources/include/toonzqt/menubarcommand.h
+++ b/toonz/sources/include/toonzqt/menubarcommand.h
@@ -77,7 +77,7 @@ enum CommandType {
 
 //-----------------------------------------------------------------------------
 
-class AuxActionsCreator {
+class DVAPI AuxActionsCreator {
 public:
   AuxActionsCreator();
   virtual ~AuxActionsCreator(){};

--- a/toonz/sources/include/toonzqt/selectioncommandids.h
+++ b/toonz/sources/include/toonzqt/selectioncommandids.h
@@ -26,6 +26,7 @@
 
 #define MI_Group "MI_Group"
 #define MI_Ungroup "MI_Ungroup"
+#define MI_UngroupAll "MI_UngroupAll"
 #define MI_BringToFront "MI_BringToFront"
 #define MI_BringForward "MI_BringForward"
 #define MI_SendBack "MI_SendBack"

--- a/toonz/sources/include/toonzqt/selectioncommandids.h
+++ b/toonz/sources/include/toonzqt/selectioncommandids.h
@@ -26,6 +26,7 @@
 
 #define MI_Group "MI_Group"
 #define MI_Ungroup "MI_Ungroup"
+#define MI_UngroupAllSelected "MI_UngroupAllSelected"
 #define MI_UngroupAll "MI_UngroupAll"
 #define MI_BringToFront "MI_BringToFront"
 #define MI_BringForward "MI_BringForward"

--- a/toonz/sources/tnztools/CMakeLists.txt
+++ b/toonz/sources/tnztools/CMakeLists.txt
@@ -89,6 +89,7 @@ set(SOURCES
     hooktool.cpp
     hookselection.cpp
     imagegrouping.cpp
+    ungroupallselection.cpp
     irontool.cpp
     levelselection.cpp
     magnettool.cpp

--- a/toonz/sources/tnztools/imagegrouping.cpp
+++ b/toonz/sources/tnztools/imagegrouping.cpp
@@ -73,6 +73,101 @@ void ungroupWithoutUndo(TVectorImage *vimg, StrokeSelection *selection) {
 }
 
 //=============================================================================
+// Group hierarchy snapshot helpers
+//-----------------------------------------------------------------------------
+
+struct GroupSpan {
+  int m_fromStroke;
+  int m_count;
+  int m_depth;
+};
+
+struct GroupingSnapshot {
+  std::vector<GroupSpan> m_groups;
+  int m_maxDepth;
+  int m_enteredGroupDepth;
+  int m_enteredGroupStroke;
+
+  GroupingSnapshot()
+      : m_maxDepth(0)
+      , m_enteredGroupDepth(0)
+      , m_enteredGroupStroke(-1) {}
+};
+
+GroupingSnapshot captureGrouping(TVectorImage *vimg) {
+  GroupingSnapshot snapshot;
+  const int strokeCount = (int)vimg->getStrokeCount();
+
+  for (int i = 0; i < strokeCount; i++) {
+    int depth = vimg->getGroupDepth(i);
+    if (depth > snapshot.m_maxDepth) snapshot.m_maxDepth = depth;
+  }
+
+  for (int depth = 1; depth <= snapshot.m_maxDepth; depth++) {
+    for (int i = 0; i < strokeCount;) {
+      if (vimg->getGroupDepth(i) < depth) {
+        i++;
+        continue;
+      }
+
+      const int fromStroke = i++;
+      while (i < strokeCount &&
+             vimg->getCommonGroupDepth(fromStroke, i) >= depth)
+        i++;
+
+      GroupSpan span = {fromStroke, i - fromStroke, depth};
+      snapshot.m_groups.push_back(span);
+    }
+  }
+
+  snapshot.m_enteredGroupDepth = vimg->isInsideGroup();
+  if (snapshot.m_enteredGroupDepth > 0) {
+    for (int i = 0; i < strokeCount; i++) {
+      if (vimg->isEnteredGroupStroke(i)) {
+        snapshot.m_enteredGroupStroke = i;
+        break;
+      }
+    }
+  }
+
+  return snapshot;
+}
+
+void ungroupAllWithoutUndo(TVectorImage *vimg) {
+  bool foundGroup;
+  do {
+    foundGroup = false;
+    for (int i = 0; i < (int)vimg->getStrokeCount();) {
+      if (!vimg->isStrokeGrouped(i)) {
+        i++;
+        continue;
+      }
+
+      i += vimg->ungroup(i);
+      foundGroup = true;
+    }
+  } while (foundGroup);
+}
+
+void restoreGroupingWithoutUndo(TVectorImage *vimg,
+                                const GroupingSnapshot &snapshot) {
+  ungroupAllWithoutUndo(vimg);
+
+  for (int depth = snapshot.m_maxDepth; depth > 0; depth--) {
+    for (const GroupSpan &span : snapshot.m_groups) {
+      if (span.m_depth == depth)
+        vimg->group(span.m_fromStroke, span.m_count);
+    }
+  }
+
+  if (snapshot.m_enteredGroupDepth > 0 &&
+      snapshot.m_enteredGroupStroke >= 0) {
+    for (int depth = 0; depth < snapshot.m_enteredGroupDepth; depth++)
+      if (!vimg->enterGroup(snapshot.m_enteredGroupStroke)) break;
+  }
+}
+
+//=============================================================================
 // GroupUndo
 //-----------------------------------------------------------------------------
 
@@ -104,26 +199,39 @@ public:
 //-----------------------------------------------------------------------------
 
 class UngroupUndo final : public ToolUtils::TToolUndo {
-  std::unique_ptr<StrokeSelection> m_selection;
+  GroupingSnapshot m_before;
+  GroupingSnapshot m_after;
+  QString m_name;
+
+  void apply(const GroupingSnapshot &snapshot) const {
+    TVectorImageP image = m_level->getFrame(m_frameId, true);
+    if (!image) return;
+
+    QMutexLocker lock(image->getMutex());
+    restoreGroupingWithoutUndo(image.getPointer(), snapshot);
+    notifyImageChanged();
+  }
 
 public:
   UngroupUndo(TXshSimpleLevel *level, const TFrameId &frameId,
-              StrokeSelection *selection)
-      : ToolUtils::TToolUndo(level, frameId), m_selection(selection) {}
+              const GroupingSnapshot &before,
+              const GroupingSnapshot &after, const QString &name)
+      : ToolUtils::TToolUndo(level, frameId)
+      , m_before(before)
+      , m_after(after)
+      , m_name(name) {}
 
-  void undo() const override {
-    TVectorImageP image = m_level->getFrame(m_frameId, true);
-    if (image) groupWithoutUndo(image.getPointer(), m_selection.get());
+  void undo() const override { apply(m_before); }
+
+  void redo() const override { apply(m_after); }
+
+  int getSize() const override {
+    return sizeof(*this) +
+           (m_before.m_groups.capacity() + m_after.m_groups.capacity()) *
+               sizeof(GroupSpan);
   }
 
-  void redo() const override {
-    TVectorImageP image = m_level->getFrame(m_frameId, true);
-    if (image) ungroupWithoutUndo(image.getPointer(), m_selection.get());
-  }
-
-  int getSize() const override { return sizeof(*this); }
-
-  QString getToolName() override { return QObject::tr("Ungroup"); }
+  QString getToolName() override { return m_name; }
 };
 
 //=============================================================================
@@ -272,6 +380,12 @@ UCHAR TGroupCommand::getGroupingOptions() {
   int count  = 0;
   UINT i, j;
 
+  for (i = 0; i < vimg->getStrokeCount(); i++)
+    if (vimg->isStrokeGrouped(i)) {
+      mask |= UNGROUP_ALL;
+      break;
+    }
+
   // spostamento: si possono  spostare solo gruppi interi  oppure  stroke   non
   // gruppate
 
@@ -308,7 +422,7 @@ selezionato
           }
    */
 
-  if (strokeIndexes.empty()) return 0;  // no stroke selected
+  if (strokeIndexes.empty()) return mask;  // no stroke selected
 
   int strokeIndex = vimg->getStrokeIndex(strokeIndexes[0].first);
 
@@ -555,11 +669,43 @@ void TGroupCommand::ungroup() {
   }
 
   QMutexLocker lock(vimg->getMutex());
+  GroupingSnapshot before = captureGrouping(vimg);
   ungroupWithoutUndo(vimg, m_sel);
+  GroupingSnapshot after = captureGrouping(vimg);
   TXshSimpleLevel *level =
       TTool::getApplication()->getCurrentLevel()->getSimpleLevel();
-  TUndoManager::manager()->add(new UngroupUndo(level, tool->getCurrentFid(),
-                                               new StrokeSelection(*m_sel)));
+  TUndoManager::manager()->add(
+      new UngroupUndo(level, tool->getCurrentFid(), before, after,
+                      QObject::tr("Ungroup")));
+}
+
+//-----------------------------------------------------------------------------
+
+void TGroupCommand::ungroupAll() {
+  if (!(getGroupingOptions() & UNGROUP_ALL)) return;
+
+  TTool *tool = TTool::getApplication()->getCurrentTool()->getTool();
+  if (!tool) return;
+  TVectorImage *vimg = (TVectorImage *)tool->getImage(true);
+  if (!vimg) return;
+
+  if (!m_sel->isEditable()) {
+    DVGui::error(QObject::tr(
+        "The drawing cannot be ungrouped. It is not editable."));
+    return;
+  }
+
+  QMutexLocker lock(vimg->getMutex());
+  GroupingSnapshot before = captureGrouping(vimg);
+  ungroupAllWithoutUndo(vimg);
+  GroupingSnapshot after = captureGrouping(vimg);
+  tool->notifyImageChanged();
+
+  TXshSimpleLevel *level =
+      TTool::getApplication()->getCurrentLevel()->getSimpleLevel();
+  TUndoManager::manager()->add(
+      new UngroupUndo(level, tool->getCurrentFid(), before, after,
+                      QObject::tr("Ungroup All in Drawing")));
 }
 
 //-----------------------------------------------------------------------------
@@ -795,7 +941,11 @@ void TGroupCommand::addMenuItems(QMenu *menu) {
   if (optionMask & TGroupCommand::UNGROUP)
     menu->addAction(cm->getAction(MI_Ungroup));
 
-  if (optionMask & (TGroupCommand::GROUP | TGroupCommand::UNGROUP) &&
+  if (optionMask & TGroupCommand::UNGROUP_ALL)
+    menu->addAction(cm->getAction(MI_UngroupAll));
+
+  if (optionMask & (TGroupCommand::GROUP | TGroupCommand::UNGROUP |
+                    TGroupCommand::UNGROUP_ALL) &&
       optionMask & (TGroupCommand::FORWARD | TGroupCommand::BACKWARD))
     menu->addSeparator();
 

--- a/toonz/sources/tnztools/strokeselection.cpp
+++ b/toonz/sources/tnztools/strokeselection.cpp
@@ -791,6 +791,8 @@ void StrokeSelection::enableCommands() {
 
   enableCommand(m_groupCommand.get(), MI_Group, &TGroupCommand::group);
   enableCommand(m_groupCommand.get(), MI_Ungroup, &TGroupCommand::ungroup);
+  enableCommand(m_groupCommand.get(), MI_UngroupAll,
+                &TGroupCommand::ungroupAll);
   enableCommand(m_groupCommand.get(), MI_BringToFront, &TGroupCommand::front);
   enableCommand(m_groupCommand.get(), MI_BringForward, &TGroupCommand::forward);
   enableCommand(m_groupCommand.get(), MI_SendBack, &TGroupCommand::back);

--- a/toonz/sources/tnztools/ungroupallselection.cpp
+++ b/toonz/sources/tnztools/ungroupallselection.cpp
@@ -1,0 +1,273 @@
+#include "tools/imagegrouping.h"
+
+// TnzTools includes
+#include "tools/strokeselection.h"
+#include "tools/tool.h"
+#include "tools/toolhandle.h"
+#include "tools/toolutils.h"
+
+// TnzQt includes
+#include "toonzqt/dvdialog.h"
+#include "toonzqt/menubarcommand.h"
+#include "toonzqt/selectioncommandids.h"
+#include "toonzqt/tselectionhandle.h"
+
+// TnzLib includes
+#include "toonz/txshlevelhandle.h"
+
+// TnzCore includes
+#include "tthreadmessage.h"
+#include "tundo.h"
+#include "tvectorimage.h"
+
+// Qt includes
+#include <QAction>
+#include <QMutexLocker>
+
+#include <algorithm>
+
+//=============================================================================
+namespace {
+//-----------------------------------------------------------------------------
+// Selection-scoped recursive ungroup
+//
+// The behavior in this file is adapted from Tahoma2D PR 2064 by @manongjohn:
+// https://github.com/tahoma2d/tahoma2d/pull/2064
+//
+// Tahoma2D removes nested group IDs directly. OpenToonz uses the hierarchy
+// snapshot mechanism established by this PR instead, so the operation can keep
+// the entered outer group while reusing the same structural Undo model as the
+// native OpenToonz foundation.
+//-----------------------------------------------------------------------------
+
+struct SelectedGroupSpan {
+  int m_fromStroke;
+  int m_count;
+  int m_depth;
+};
+
+struct SelectedGroupingSnapshot {
+  std::vector<SelectedGroupSpan> m_groups;
+  int m_maxDepth;
+  int m_enteredGroupDepth;
+  int m_enteredGroupStroke;
+
+  SelectedGroupingSnapshot()
+      : m_maxDepth(0)
+      , m_enteredGroupDepth(0)
+      , m_enteredGroupStroke(-1) {}
+};
+
+SelectedGroupingSnapshot captureSelectedGrouping(TVectorImage *vimg) {
+  SelectedGroupingSnapshot snapshot;
+  const int strokeCount = (int)vimg->getStrokeCount();
+
+  for (int i = 0; i < strokeCount; i++) {
+    int depth = vimg->getGroupDepth(i);
+    if (depth > snapshot.m_maxDepth) snapshot.m_maxDepth = depth;
+  }
+
+  for (int depth = 1; depth <= snapshot.m_maxDepth; depth++) {
+    for (int i = 0; i < strokeCount;) {
+      if (vimg->getGroupDepth(i) < depth) {
+        i++;
+        continue;
+      }
+
+      const int fromStroke = i++;
+      while (i < strokeCount &&
+             vimg->getCommonGroupDepth(fromStroke, i) >= depth)
+        i++;
+
+      SelectedGroupSpan span = {fromStroke, i - fromStroke, depth};
+      snapshot.m_groups.push_back(span);
+    }
+  }
+
+  snapshot.m_enteredGroupDepth = vimg->isInsideGroup();
+  if (snapshot.m_enteredGroupDepth > 0) {
+    for (int i = 0; i < strokeCount; i++) {
+      if (vimg->isEnteredGroupStroke(i)) {
+        snapshot.m_enteredGroupStroke = i;
+        break;
+      }
+    }
+  }
+
+  return snapshot;
+}
+
+void ungroupEveryGroupWithoutUndo(TVectorImage *vimg) {
+  bool foundGroup;
+  do {
+    foundGroup = false;
+    for (int i = 0; i < (int)vimg->getStrokeCount();) {
+      if (!vimg->isStrokeGrouped(i)) {
+        i++;
+        continue;
+      }
+
+      i += vimg->ungroup(i);
+      foundGroup = true;
+    }
+  } while (foundGroup);
+}
+
+void restoreSelectedGroupingWithoutUndo(
+    TVectorImage *vimg, const SelectedGroupingSnapshot &snapshot) {
+  ungroupEveryGroupWithoutUndo(vimg);
+
+  for (int depth = snapshot.m_maxDepth; depth > 0; depth--) {
+    for (const SelectedGroupSpan &span : snapshot.m_groups) {
+      if (span.m_depth == depth)
+        vimg->group(span.m_fromStroke, span.m_count);
+    }
+  }
+
+  if (snapshot.m_enteredGroupDepth > 0 &&
+      snapshot.m_enteredGroupStroke >= 0) {
+    for (int depth = 0; depth < snapshot.m_enteredGroupDepth; depth++)
+      if (!vimg->enterGroup(snapshot.m_enteredGroupStroke)) break;
+  }
+}
+
+bool spanContainsSelection(const SelectedGroupSpan &span,
+                           StrokeSelection *selection) {
+  for (int i = span.m_fromStroke; i < span.m_fromStroke + span.m_count; i++)
+    if (selection->isSelected(i)) return true;
+  return false;
+}
+
+SelectedGroupingSnapshot makeSelectionUngroupAllSnapshot(
+    const SelectedGroupingSnapshot &source, StrokeSelection *selection) {
+  SelectedGroupingSnapshot target = source;
+  target.m_groups.clear();
+  target.m_maxDepth = 0;
+
+  for (const SelectedGroupSpan &span : source.m_groups) {
+    // The entered hierarchy is the editing context, not part of the selected
+    // group to flatten. Only group levels below that context are removed.
+    if (span.m_depth > source.m_enteredGroupDepth &&
+        spanContainsSelection(span, selection))
+      continue;
+
+    target.m_groups.push_back(span);
+    target.m_maxDepth = std::max(target.m_maxDepth, span.m_depth);
+  }
+
+  return target;
+}
+
+//=============================================================================
+// SelectedUngroupAllUndo
+//-----------------------------------------------------------------------------
+
+class SelectedUngroupAllUndo final : public ToolUtils::TToolUndo {
+  SelectedGroupingSnapshot m_before;
+  SelectedGroupingSnapshot m_after;
+
+  void apply(const SelectedGroupingSnapshot &snapshot) const {
+    TVectorImageP image = m_level->getFrame(m_frameId, true);
+    if (!image) return;
+
+    QMutexLocker lock(image->getMutex());
+    restoreSelectedGroupingWithoutUndo(image.getPointer(), snapshot);
+    notifyImageChanged();
+  }
+
+public:
+  SelectedUngroupAllUndo(TXshSimpleLevel *level, const TFrameId &frameId,
+                         const SelectedGroupingSnapshot &before,
+                         const SelectedGroupingSnapshot &after)
+      : ToolUtils::TToolUndo(level, frameId)
+      , m_before(before)
+      , m_after(after) {}
+
+  void undo() const override { apply(m_before); }
+  void redo() const override { apply(m_after); }
+
+  int getSize() const override {
+    return sizeof(*this) +
+           (m_before.m_groups.capacity() + m_after.m_groups.capacity()) *
+               sizeof(SelectedGroupSpan);
+  }
+
+  QString getToolName() override { return QObject::tr("Ungroup All"); }
+};
+
+//=============================================================================
+// Command registration
+//-----------------------------------------------------------------------------
+
+class UngroupAllSelectedHandler final : public CommandHandlerInterface {
+public:
+  void execute() override {
+    StrokeSelection *selection =
+        dynamic_cast<StrokeSelection *>(TSelection::getCurrent());
+    if (!selection) return;
+
+    TGroupCommand *command = selection->getGroupCommand();
+    if (command) command->ungroupSelectedAll();
+  }
+};
+
+class UngroupAllSelectedActionsCreator final : public AuxActionsCreator {
+public:
+  void createActions(QObject *parent) override {
+    QAction *action = new QAction(QObject::tr("Ungroup All"), parent);
+    CommandManager *commandManager = CommandManager::instance();
+    commandManager->define(MI_UngroupAllSelected, MenuEditCommandType, "",
+                           action, "ungroup");
+    commandManager->setHandler(MI_UngroupAllSelected,
+                               new UngroupAllSelectedHandler());
+
+    auto updateEnabled = [action](TSelection *selection) {
+      action->setEnabled(dynamic_cast<StrokeSelection *>(selection) != nullptr);
+    };
+
+    updateEnabled(TSelection::getCurrent());
+    QObject::connect(
+        TSelectionHandle::getCurrent(), &TSelectionHandle::selectionSwitched,
+        action, [updateEnabled](TSelection *, TSelection *current) {
+          updateEnabled(current);
+        });
+  }
+};
+
+UngroupAllSelectedActionsCreator s_ungroupAllSelectedActionsCreator;
+
+//-----------------------------------------------------------------------------
+}  // namespace
+//-----------------------------------------------------------------------------
+
+void TGroupCommand::ungroupSelectedAll() {
+  // Match ordinary Ungroup eligibility: the selected strokes must represent
+  // complete group(s) at the current entered-group depth.
+  if (!(getGroupingOptions() & UNGROUP)) return;
+
+  TTool *tool = TTool::getApplication()->getCurrentTool()->getTool();
+  if (!tool) return;
+
+  TVectorImage *vimg = (TVectorImage *)tool->getImage(true);
+  if (!vimg) return;
+
+  if (!m_sel || !m_sel->isEditable()) {
+    DVGui::error(
+        QObject::tr("The selection cannot be ungrouped. It is not editable."));
+    return;
+  }
+
+  QMutexLocker lock(vimg->getMutex());
+  SelectedGroupingSnapshot before = captureSelectedGrouping(vimg);
+  SelectedGroupingSnapshot target =
+      makeSelectionUngroupAllSnapshot(before, m_sel);
+
+  restoreSelectedGroupingWithoutUndo(vimg, target);
+  SelectedGroupingSnapshot after = captureSelectedGrouping(vimg);
+  tool->notifyImageChanged();
+
+  TXshSimpleLevel *level =
+      TTool::getApplication()->getCurrentLevel()->getSimpleLevel();
+  TUndoManager::manager()->add(new SelectedUngroupAllUndo(
+      level, tool->getCurrentFid(), before, after));
+}

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2296,6 +2296,8 @@ void MainWindow::defineActions() {
   createMenuEditAction(MI_Group, QT_TR_NOOP("&Group"), "Ctrl+G", "group");
   createMenuEditAction(MI_Ungroup, QT_TR_NOOP("&Ungroup"), "Ctrl+Shift+G",
                        "ungroup");
+  createMenuEditAction(MI_UngroupAll,
+                       QT_TR_NOOP("Ungroup &All in Drawing"), "", "ungroup");
   createMenuEditAction(MI_EnterGroup, QT_TR_NOOP("&Enter Group"), "",
                        "enter_group");
   createMenuEditAction(MI_ExitGroup, QT_TR_NOOP("&Exit Group"), "",

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -1204,6 +1204,8 @@ QMenuBar *StackedMenuBar::createFullMenuBar() {
   {
     addMenuItem(groupMenu, MI_Group);
     addMenuItem(groupMenu, MI_Ungroup);
+    addMenuItem(groupMenu, MI_UngroupAll);
+    groupMenu->addSeparator();
     addMenuItem(groupMenu, MI_EnterGroup);
     addMenuItem(groupMenu, MI_ExitGroup);
   }


### PR DESCRIPTION
## Summary

- adds **Edit > Group > Ungroup All in Drawing** for the current vector drawing
- recursively removes every explicit group and nested subgroup without requiring a stroke selection
- replaces selection-based Ungroup undo reconstruction with a compact group-hierarchy snapshot, preserving separate sibling groups and nested group boundaries
- adds the command to the Default, Studio Ghibli, and full/fallback menus without adding another default Command Bar button

## Behavior

- affects only the current drawing/frame
- preserves stroke order, geometry, styles, and selection indexes
- exits any entered group while flattening the drawing
- restores the complete hierarchy and entered-group context with one Undo operation
- leaves the command without a default shortcut; it remains assignable through Configure Shortcuts

## Foundation status

The native OpenToonz foundation is contained in the first and currently only commit, **Add Ungroup All in Drawing** (`1fb5fe79b7f3963e29437552e71cd8ebbb81a9fd`). It is rebased directly on the current `main` branch.

Subsequent work adapting Tahoma2D's `Ungroup All` implementation and selection-oriented concepts will be kept in a separate second commit with explicit Tahoma2D / PR #2064 / @manongjohn attribution. This keeps the provenance of the OpenToonz foundation and the later Tahoma2D-derived work clear in history.

## Validation

- patch generation completed with `git diff --check`
- randomized structural checks validated capture/restore across contiguous sibling and nested group hierarchies
- Windows Build workflow run completed successfully for the original foundation source tree
- CI run completed successfully for the identical pre-squash foundation tree
- the squashed commit preserves the same source diff while rebasing it directly onto current `main`
- manual artifact testing remains appropriate before final merge

## Manual test cases

1. several separate sibling groups, followed by Undo and Redo
2. two or more levels of nested groups
3. mixed grouped and ungrouped strokes
4. command invoked with no selected strokes
5. invocation while entered into a nested group
6. filled vector drawings, checking fills and stroke order before and after Undo

## Planned follow-up within this PR

Adapt the strongest parts of Tahoma2D PR #2064 as a separate, credited second commit. In particular, evaluate its selection-scoped recursive Ungroup All behavior, entered-group semantics, lower-level recursive ungroup primitive, and exact grouping-state restoration without conflating those changes with this OpenToonz foundation.

Addresses opentoonz/opentoonz#1840.