### PR TITLE
Option to Hide Style Indexes (Hidden by default)

### DIFF
--- a/toonz/sources/include/toonzqt/paletteviewergui.h
+++ b/toonz/sources/include/toonzqt/paletteviewergui.h
@@ -153,8 +153,8 @@ public:
   NameDisplayMode getNameDisplayMode() const { return m_nameDisplayMode; }
   void setNameDisplayMode(NameDisplayMode mode);
 
-  void toggleShowStyleIndex();
-  bool getShowStyleIndex();
+  void setShowStyleIndex(bool showStyleIndex);
+  bool getShowStyleIndex() const;
   PaletteViewerGUI::PaletteViewType getViewType() const { return m_viewType; }
 
   int posToIndex(const QPoint &pos) const;

--- a/toonz/sources/include/toonzqt/paletteviewergui.h
+++ b/toonz/sources/include/toonzqt/paletteviewergui.h
@@ -153,6 +153,8 @@ public:
   NameDisplayMode getNameDisplayMode() const { return m_nameDisplayMode; }
   void setNameDisplayMode(NameDisplayMode mode);
 
+  void toggleShowStyleIndex();
+  bool getShowStyleIndex();
   PaletteViewerGUI::PaletteViewType getViewType() const { return m_viewType; }
 
   int posToIndex(const QPoint &pos) const;

--- a/toonz/sources/toonzqt/paletteviewer.cpp
+++ b/toonz/sources/toonzqt/paletteviewer.cpp
@@ -43,6 +43,7 @@
 #include <QApplication>
 #include <QLabel>
 #include <QDrag>
+#include <QSignalBlocker>
 
 TEnv::IntVar ShowNewStyleButton("ShowNewStyleButton", 1);
 using namespace PaletteViewerGUI;
@@ -496,23 +497,41 @@ void PaletteViewer::createPaletteToolBar() {
   addViewAction(tr("&Large Thumbnails View"), PageViewer::LargeChips);
   addViewAction(tr("&List View"), PageViewer::List);
 
-  m_viewMode->addSeparator();
-  QAction *showStyleIndex = new QAction(tr("Show Style Index"), this);
-  showStyleIndex->setCheckable(true);
-  if (m_pageViewer)
-    showStyleIndex->setChecked(m_pageViewer->getShowStyleIndex());
-  connect(showStyleIndex, &QAction::toggled, [=](bool checked) {
-    if (m_pageViewer) m_pageViewer->toggleShowStyleIndex();
-    if (m_pageViewer) m_pageViewer->update();
-    bool setChecked              = false;
-    if (m_pageViewer) setChecked = m_pageViewer->getShowStyleIndex();
-    showStyleIndex->setChecked(setChecked);
-  });
-  m_viewMode->addAction(showStyleIndex);
+  viewMode->addSeparator();
+
+  QActionGroup *nameDisplayModeGroup = new QActionGroup(viewMode);
+  nameDisplayModeGroup->setExclusive(true);
+  connect(nameDisplayModeGroup, &QActionGroup::triggered, this,
+          &PaletteViewer::onNameDisplayMode);
+
+  auto addNameDisplayAction = [&](const QString &label,
+                                  PageViewer::NameDisplayMode mode) {
+    QAction *nameDisplayAction = new QAction(label, viewMode);
+    nameDisplayAction->setData(mode);
+    nameDisplayAction->setCheckable(true);
+    if (m_pageViewer->getNameDisplayMode() == mode)
+      nameDisplayAction->setChecked(true);
+    nameDisplayModeGroup->addAction(nameDisplayAction);
+    viewMode->addAction(nameDisplayAction);
+  };
 
   addNameDisplayAction(tr("Style Name"), PageViewer::Style);
   addNameDisplayAction(tr("StudioPalette Name"), PageViewer::Original);
   addNameDisplayAction(tr("Both Names"), PageViewer::StyleAndOriginal);
+
+  QAction *showStyleIndexesAction =
+      new QAction(tr("Show Style Indexes"), viewMode);
+  showStyleIndexesAction->setCheckable(true);
+  showStyleIndexesAction->setChecked(m_pageViewer->getShowStyleIndex());
+  connect(showStyleIndexesAction, &QAction::toggled, this,
+          [this](bool checked) { m_pageViewer->setShowStyleIndex(checked); });
+  connect(viewMode, &QMenu::aboutToShow, this,
+          [this, showStyleIndexesAction]() {
+            QSignalBlocker blocker(showStyleIndexesAction);
+            showStyleIndexesAction->setChecked(
+                m_pageViewer->getShowStyleIndex());
+          });
+  viewMode->addAction(showStyleIndexesAction);
 
   viewMode->addSeparator();
 

--- a/toonz/sources/toonzqt/paletteviewer.cpp
+++ b/toonz/sources/toonzqt/paletteviewer.cpp
@@ -496,23 +496,19 @@ void PaletteViewer::createPaletteToolBar() {
   addViewAction(tr("&Large Thumbnails View"), PageViewer::LargeChips);
   addViewAction(tr("&List View"), PageViewer::List);
 
-  viewMode->addSeparator();
-
-  QActionGroup *nameDisplayModeGroup = new QActionGroup(viewMode);
-  nameDisplayModeGroup->setExclusive(true);
-  connect(nameDisplayModeGroup, &QActionGroup::triggered, this,
-          &PaletteViewer::onNameDisplayMode);
-
-  auto addNameDisplayAction = [&](const QString &label,
-                                  PageViewer::NameDisplayMode mode) {
-    QAction *nameDisplayAction = new QAction(label, viewMode);
-    nameDisplayAction->setData(mode);
-    nameDisplayAction->setCheckable(true);
-    if (m_pageViewer->getNameDisplayMode() == mode)
-      nameDisplayAction->setChecked(true);
-    nameDisplayModeGroup->addAction(nameDisplayAction);
-    viewMode->addAction(nameDisplayAction);
-  };
+  m_viewMode->addSeparator();
+  QAction *showStyleIndex = new QAction(tr("Show Style Index"), this);
+  showStyleIndex->setCheckable(true);
+  if (m_pageViewer)
+    showStyleIndex->setChecked(m_pageViewer->getShowStyleIndex());
+  connect(showStyleIndex, &QAction::toggled, [=](bool checked) {
+    if (m_pageViewer) m_pageViewer->toggleShowStyleIndex();
+    if (m_pageViewer) m_pageViewer->update();
+    bool setChecked              = false;
+    if (m_pageViewer) setChecked = m_pageViewer->getShowStyleIndex();
+    showStyleIndex->setChecked(setChecked);
+  });
+  m_viewMode->addAction(showStyleIndex);
 
   addNameDisplayAction(tr("Style Name"), PageViewer::Style);
   addNameDisplayAction(tr("StudioPalette Name"), PageViewer::Original);

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -42,7 +42,7 @@ TEnv::IntVar EnvSoftwareCurrentFontSize_StyleName(
     "SoftwareCurrentFontSize_StyleName", 11);
 extern TEnv::IntVar ShowNewStyleButton;
 
-TEnv::IntVar ShowStyleIndex("ShowStyleIndex", 0);
+TEnv::IntVar ShowStyleIndex("ShowStyleIndex", 1);
 
 using namespace PaletteViewerGUI;
 using namespace DVGui;

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -231,19 +231,17 @@ int PageViewer::getCurrentStyleIndex() const {
 
 //-----------------------------------------------------------------------------
 
-void PageViewer::toggleShowStyleIndex() {
-  if (ShowStyleIndex == 1) {
-    ShowStyleIndex = 0;
-  } else {
-    ShowStyleIndex = 1;
-  }
+void PageViewer::setShowStyleIndex(bool showStyleIndex) {
+  if (getShowStyleIndex() == showStyleIndex) return;
+
+  ShowStyleIndex = showStyleIndex ? 1 : 0;
+  update();
 }
 
 //-----------------------------------------------------------------------------
 
-bool PageViewer::getShowStyleIndex() { return ShowStyleIndex == 1; }
+bool PageViewer::getShowStyleIndex() const { return ShowStyleIndex != 0; }
 
-//-----------------------------------------------------------------------------/*! Set current page to \b page and update view.
 /*! Set current page to \b page and update view.
  */
 void PageViewer::setPage(TPalette::Page *page) {
@@ -868,20 +866,23 @@ void PageViewer::paintEvent(QPaintEvent *e) {
       tmpFont.setPointSize(9);
       tmpFont.setItalic(false);
       p.setFont(tmpFont);
-      if (ShowStyleIndex == 1) {
-      int indexWidth = fontMetrics().width(QString().setNum(styleIndex)) + 4;
-      QRect indexRect(chipRect.bottomRight() + QPoint(-indexWidth, -14),
-                      chipRect.bottomRight());
-      p.setPen(Qt::black);
-      p.setBrush(Qt::white);
-      p.drawRect(indexRect);
-      p.drawText(indexRect, Qt::AlignCenter, QString().setNum(styleIndex));
+      if (getShowStyleIndex()) {
+        int indexWidth =
+            fontMetrics().horizontalAdvance(QString().setNum(styleIndex)) + 4;
+        QRect indexRect(chipRect.bottomRight() + QPoint(-indexWidth, -14),
+                        chipRect.bottomRight());
+        p.setPen(Qt::black);
+        p.setBrush(Qt::white);
+        p.drawRect(indexRect);
+        p.drawText(indexRect, Qt::AlignCenter, QString().setNum(styleIndex));
       }
-        
+
       // draw "Autopaint for lines" indicator
       int offset = 0;
       if (style->getFlags() != 0) {
         QRect aflRect(chipRect.bottomLeft() + QPoint(0, -14), QSize(12, 15));
+        p.setPen(Qt::black);
+        p.fillRect(aflRect, QBrush(Qt::white));
         p.drawRect(aflRect);
         p.drawText(aflRect, Qt::AlignCenter, "A");
         offset += 12;
@@ -928,7 +929,7 @@ void PageViewer::paintEvent(QPaintEvent *e) {
     // draw new style chip
     if (ShowNewStyleButton && !m_page->getPalette()->isLocked()) {
       i              = getChipCount();
-      QRect chipRect = getItemRect(i).adjusted(0, -1, 0, -1);
+      QRect chipRect = getItemRect(i).adjusted(4, 4, -5, -5);
       p.setPen(
           QColor(textColor.red(), textColor.green(), textColor.blue(), 128));
       p.fillRect(chipRect, QBrush(QColor(0, 0, 0, 64)));

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -242,6 +242,8 @@ void PageViewer::setShowStyleIndex(bool showStyleIndex) {
 
 bool PageViewer::getShowStyleIndex() const { return ShowStyleIndex != 0; }
 
+//-----------------------------------------------------------------------------
+
 /*! Set current page to \b page and update view.
  */
 void PageViewer::setPage(TPalette::Page *page) {
@@ -893,6 +895,7 @@ void PageViewer::paintEvent(QPaintEvent *e) {
           m_viewMode != SmallChips) {
         QRect ppRect(chipRect.bottomLeft() + QPoint(offset, -14),
                      QSize(12, 15));
+        p.fillRect(ppRect, QBrush(Qt::white));
         p.drawRect(ppRect);
         QPoint markPos = ppRect.center() + QPoint(1, 0);
         p.drawEllipse(markPos, 3, 3);

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -870,12 +870,12 @@ void PageViewer::paintEvent(QPaintEvent *e) {
       p.setFont(tmpFont);
       if (ShowStyleIndex == 1) {
         int indexWidth = fontMetrics().width(QString().setNum(styleIndex)) + 4;
-        QRect indexRect(chipRect.bottomRight() + QPoint(-indexWidth, -14),
+      QRect indexRect(chipRect.bottomRight() + QPoint(-indexWidth, -14),
                         chipRect.bottomRight());
-        p.setPen(Qt::black);
-        p.setBrush(Qt::white);
-        p.drawRect(indexRect);
-        p.drawText(indexRect, Qt::AlignCenter, QString().setNum(styleIndex));
+      p.setPen(Qt::black);
+      p.setBrush(Qt::white);
+      p.drawRect(indexRect);
+      p.drawText(indexRect, Qt::AlignCenter, QString().setNum(styleIndex));
       }
       // draw "Autopaint for lines" indicator
       int offset = 0;

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -42,6 +42,8 @@ TEnv::IntVar EnvSoftwareCurrentFontSize_StyleName(
     "SoftwareCurrentFontSize_StyleName", 11);
 extern TEnv::IntVar ShowNewStyleButton;
 
+TEnv::IntVar ShowStyleIndex("ShowStyleIndex", 0);
+
 using namespace PaletteViewerGUI;
 using namespace DVGui;
 
@@ -228,6 +230,20 @@ int PageViewer::getCurrentStyleIndex() const {
 }
 
 //-----------------------------------------------------------------------------
+
+void PageViewer::toggleShowStyleIndex() {
+  if (ShowStyleIndex == 1) {
+    ShowStyleIndex = 0;
+  } else {
+    ShowStyleIndex = 1;
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+bool PageViewer::getShowStyleIndex() { return ShowStyleIndex == 1; }
+
+//-----------------------------------------------------------------------------/*! Set current page to \b page and update view.
 /*! Set current page to \b page and update view.
  */
 void PageViewer::setPage(TPalette::Page *page) {
@@ -852,15 +868,15 @@ void PageViewer::paintEvent(QPaintEvent *e) {
       tmpFont.setPointSize(9);
       tmpFont.setItalic(false);
       p.setFont(tmpFont);
-      int indexWidth =
-          fontMetrics().horizontalAdvance(QString().setNum(styleIndex)) + 4;
-      QRect indexRect(chipRect.bottomRight() + QPoint(-indexWidth, -14),
-                      chipRect.bottomRight());
-      p.setPen(Qt::black);
-      p.setBrush(Qt::white);
-      p.drawRect(indexRect);
-      p.drawText(indexRect, Qt::AlignCenter, QString().setNum(styleIndex));
-
+      if (ShowStyleIndex == 1) {
+        int indexWidth = fontMetrics().width(QString().setNum(styleIndex)) + 4;
+        QRect indexRect(chipRect.bottomRight() + QPoint(-indexWidth, -14),
+                        chipRect.bottomRight());
+        p.setPen(Qt::black);
+        p.setBrush(Qt::white);
+        p.drawRect(indexRect);
+        p.drawText(indexRect, Qt::AlignCenter, QString().setNum(styleIndex));
+      }
       // draw "Autopaint for lines" indicator
       int offset = 0;
       if (style->getFlags() != 0) {
@@ -911,7 +927,7 @@ void PageViewer::paintEvent(QPaintEvent *e) {
     // draw new style chip
     if (ShowNewStyleButton && !m_page->getPalette()->isLocked()) {
       i              = getChipCount();
-      QRect chipRect = getItemRect(i).adjusted(4, 4, -5, -5);
+      QRect chipRect = getItemRect(i).adjusted(0, -1, 0, -1);
       p.setPen(
           QColor(textColor.red(), textColor.green(), textColor.blue(), 128));
       p.fillRect(chipRect, QBrush(QColor(0, 0, 0, 64)));

--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -869,14 +869,15 @@ void PageViewer::paintEvent(QPaintEvent *e) {
       tmpFont.setItalic(false);
       p.setFont(tmpFont);
       if (ShowStyleIndex == 1) {
-        int indexWidth = fontMetrics().width(QString().setNum(styleIndex)) + 4;
+      int indexWidth = fontMetrics().width(QString().setNum(styleIndex)) + 4;
       QRect indexRect(chipRect.bottomRight() + QPoint(-indexWidth, -14),
-                        chipRect.bottomRight());
+                      chipRect.bottomRight());
       p.setPen(Qt::black);
       p.setBrush(Qt::white);
       p.drawRect(indexRect);
       p.drawText(indexRect, Qt::AlignCenter, QString().setNum(styleIndex));
       }
+        
       // draw "Autopaint for lines" indicator
       int offset = 0;
       if (style->getFlags() != 0) {


### PR DESCRIPTION
Ports opentoonz/opentoonz#6992 into OpenToonz-Dev.

## What this changes
- Adds a palette-view option to show or hide style number indexes.
- Keeps style indexes hidden by default.
- Persists the preference through `TEnv::IntVar`.

## Authorship
This branch points directly to the original upstream PR head (`d3c6ae96657608516737e8fcc0d96ab89e6259fb`) rather than recreating or squashing the changes. The original three commits and `JParks123` authorship are therefore preserved.

## Source
- Upstream PR: opentoonz/opentoonz#6992
- Original author: @JParks123
- Upstream status: closed without merge

## Validation status
The comparison against `master` contains only the three intended palette-viewer files. Build and UI testing have not yet been performed in this repository.