### PR TITLE
[T2D-001] Allow simultaneous touch zoom and rotation

### DIFF
--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -1125,7 +1125,7 @@ void SceneViewer::gestureEvent(QGestureEvent *e) {
           decimalValue /= 1.5;
           scaleFactor = 1 - decimalValue;
         }
-        if (!m_rotating && !m_zooming) {
+        if (!m_zooming) {
           double delta = scaleFactor - 1;
           m_scaleFactor += delta;
           if (m_scaleFactor > .2 || m_scaleFactor < -.2) {
@@ -1144,7 +1144,7 @@ void SceneViewer::gestureEvent(QGestureEvent *e) {
         if (m_isFlippedX != m_isFlippedY) rotationDelta = -rotationDelta;
         TAffine aff    = getViewMatrix().inv();
         TPointD center = aff * TPointD(0, 0);
-        if (!m_rotating && !m_zooming) {
+        if (!m_rotating) {
           m_rotationDelta += rotationDelta;
           double absDelta = std::abs(m_rotationDelta);
           if (absDelta >= 10) {


### PR DESCRIPTION
## Summary

- Allow a pinch gesture to continue into rotation after zoom begins.
- Allow a rotation gesture to continue into zoom after rotation begins.

## Validation

- `git diff --check`
- Compiled `sceneviewerevents.cpp` with the configured OpenToonz build command.
- Manual touchscreen verification is pending.