### PR TITLE
[T2D-003] Add image previews to cell tooltips

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -452,6 +452,9 @@ public:
   bool isShowFrameNumberWithLettersEnabled() const {
     return getBoolValue(showFrameNumberWithLetters);
   }
+  bool isShowImagesInCellTooltipEnabled() const {
+    return getBoolValue(showImagesInCellTooltip);
+  }
   bool isLinkColumnNameWithLevelEnabled() const {
     return getBoolValue(linkColumnNameWithLevel);
   }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -156,6 +156,7 @@ enum PreferencesItemId {
   currentColumnColor,
   levelNameDisplayType,
   showFrameNumberWithLetters,
+  showImagesInCellTooltip,
   linkColumnNameWithLevel,
 
   //----------

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1369,6 +1369,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       {levelNameDisplayType, tr("Level Name Display:")},
       {showFrameNumberWithLetters,
        tr("Show \"ABC\" Appendix to the Frame Number in Xsheet Cell")},
+      {showImagesInCellTooltip, tr("Show Images in Cell Tooltips")},
       {linkColumnNameWithLevel, tr("Link Column Name with Level")},
 
       // Animation
@@ -2196,6 +2197,7 @@ QWidget* PreferencesPopup::createXsheetPage() {
     insertUI(highlightLineEverySecond, xshCellAreaLay);
     insertUI(currentTimelineEnabled, xshCellAreaLay);
     insertUI(showFrameNumberWithLetters, xshCellAreaLay);
+    insertUI(showImagesInCellTooltip, xshCellAreaLay);
   }
 
   QGridLayout* showKeyLay =

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -25,6 +25,7 @@
 #include "toonzqt/tselectionhandle.h"
 #include "historytypes.h"
 #include "toonzqt/menubarcommand.h"
+#include "toonzqt/icongenerator.h"
 
 // TnzLib includes
 #include "toonz/tscenehandle.h"
@@ -71,6 +72,7 @@
 #include <QToolTip>
 #include <QApplication>
 #include <QClipboard>
+#include <QBuffer>
 #include <QRegularExpression>
 
 namespace {
@@ -1182,6 +1184,7 @@ CellArea::CellArea(XsheetViewer *parent, Qt::WindowFlags flags)
     , m_isMousePressed(false)
     , m_pos(-1, -1)
     , m_tooltip(tr(""))
+    , m_tooltipTimer(nullptr)
     , m_renameCell(new RenameCellField(this, m_viewer)) {
   setAcceptDrops(true);
   setMouseTracking(true);
@@ -3477,7 +3480,8 @@ void CellArea::mouseMoveEvent(QMouseEvent *event) {
   } else
     m_viewer->stopAutoPan();
 
-  m_pos = pos;
+  CellPosition previousCellPosition = m_viewer->xyToPosition(m_pos);
+  m_pos                             = pos;
   if (getDragTool()) {
     getDragTool()->onDrag(event);
     return;
@@ -3486,6 +3490,10 @@ void CellArea::mouseMoveEvent(QMouseEvent *event) {
   CellPosition cellPosition = m_viewer->xyToPosition(pos);
   int row                   = cellPosition.frame();
   int col                   = cellPosition.layer();
+  if (QToolTip::isVisible() &&
+      (previousCellPosition.frame() != row ||
+       previousCellPosition.layer() != col))
+    QToolTip::hideText();
   QPoint cellTopLeft        = m_viewer->positionToXY(CellPosition(row, col));
   int x                     = m_pos.x() - cellTopLeft.x();
   int y                     = m_pos.y() - cellTopLeft.y();
@@ -3506,6 +3514,9 @@ void CellArea::mouseMoveEvent(QMouseEvent *event) {
     TXshSoundTextColumn *soundTextColumn = column->getSoundTextColumn();
     isSoundTextColumn                    = (!soundTextColumn) ? false : true;
   }
+
+  m_tooltip.clear();
+  m_tooltipCell = TXshCell();
 
   TStageObject *pegbar = xsh->getStageObject(m_viewer->getObjectId(col));
   int k0, k1;
@@ -3570,6 +3581,9 @@ void CellArea::mouseMoveEvent(QMouseEvent *event) {
                                           : QString::fromStdWString(levelName) +
                                                 QString(" ") + frameNumber);
     }
+    if (Preferences::instance()->isShowImagesInCellTooltipEnabled() &&
+        cell.getSimpleLevel())
+      m_tooltipCell = cell;
   } else if (isSoundColumn && o->rect(PredefinedRect::PREVIEW_TRACK)
                                   .adjusted(0, 0, -frameAdj.x(), -frameAdj.y())
                                   .contains(mouseInCell))
@@ -3792,9 +3806,24 @@ void CellArea::dropEvent(QDropEvent *e) {
 bool CellArea::event(QEvent *event) {
   QEvent::Type type = event->type();
   if (type == QEvent::ToolTip) {
-    if (!m_tooltip.isEmpty())
-      QToolTip::showText(mapToGlobal(m_pos), m_tooltip);
-    else
+    if (!m_tooltip.isEmpty()) {
+      if (!m_tooltipCell.isEmpty()) {
+        QPixmap icon = IconGenerator::instance()->getIcon(
+            m_tooltipCell.m_level.getPointer(), m_tooltipCell.m_frameId, true);
+        if (icon.isNull()) {
+          if (!m_tooltipTimer) {
+            m_tooltipTimer = new QTimer(this);
+            m_tooltipTimer->setSingleShot(true);
+            connect(m_tooltipTimer, SIGNAL(timeout()), this,
+                    SLOT(onDelayToolTip()));
+          }
+          m_tooltipTimer->start(50);
+          return true;
+        }
+        onDelayToolTip();
+      } else
+        QToolTip::showText(mapToGlobal(m_pos), m_tooltip);
+    } else
       QToolTip::hideText();
   }
   if (type == QEvent::WindowDeactivate && m_isMousePressed) {
@@ -3803,6 +3832,33 @@ bool CellArea::event(QEvent *event) {
     mouseReleaseEvent(&e);
   }
   return QWidget::event(event);
+}
+
+//-----------------------------------------------------------------------------
+
+void CellArea::onDelayToolTip() {
+  if (m_tooltipTimer) m_tooltipTimer->stop();
+  if (m_tooltip.isEmpty() || m_tooltipCell.isEmpty()) return;
+
+  QPixmap icon = IconGenerator::instance()->getIcon(
+      m_tooltipCell.m_level.getPointer(), m_tooltipCell.m_frameId, true);
+  if (icon.isNull()) {
+    QToolTip::showText(mapToGlobal(m_pos), m_tooltip);
+    return;
+  }
+
+  QByteArray pngData;
+  QBuffer buffer(&pngData);
+  if (!buffer.open(QIODevice::WriteOnly) || !icon.save(&buffer, "PNG", 100)) {
+    QToolTip::showText(mapToGlobal(m_pos), m_tooltip);
+    return;
+  }
+
+  QString html =
+      QString("<div class='imgtooltip'><img src='data:image/png;base64,%1'>"
+              "<div align='right'>%2</div></div>")
+          .arg(QString::fromLatin1(pngData.toBase64()), m_tooltip.toHtmlEscaped());
+  QToolTip::showText(mapToGlobal(m_pos), html);
 }
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -5,6 +5,7 @@
 
 #include <QWidget>
 #include <QLineEdit>
+#include <QTimer>
 #include "orientation.h"
 
 #include "toonz/txshcell.h"
@@ -88,6 +89,8 @@ class CellArea final : public QWidget {
 
   QPoint m_pos;
   QString m_tooltip;
+  TXshCell m_tooltipCell;
+  QTimer *m_tooltipTimer;
 
   RenameCellField *m_renameCell;
 
@@ -188,6 +191,7 @@ protected slots:
   // Replace level with another level in the cast
   void onReplaceByCastedLevel(QAction *action);
   void onSetCellMark();
+  void onDelayToolTip();
 };
 
 }  // namespace XsheetGUI

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -622,6 +622,8 @@ void Preferences::definePreferenceItems() {
          0);  // default
   define(showFrameNumberWithLetters, "showFrameNumberWithLetters",
          QMetaType::Bool, false);
+  define(showImagesInCellTooltip, "showImagesInCellTooltip", QMetaType::Bool,
+         false);
   // This option will do the following:
   // - When setting a cell in the empty column, level name will be copied to the
   // column name


### PR DESCRIPTION
## Summary
- add an opt-in Xsheet preference for simple-level image previews in cell tooltips
- retain text-only tooltips while an icon is unavailable
- hide a visible cell tooltip when the pointer moves to another cell

## Validation
- `git diff --check`
- compiled `xshcellviewer.cpp`, `preferencespopup.cpp`, `preferences.cpp`, and generated `moc_xshcellviewer.cpp`

Manual Xsheet and Timeline tooltip verification is pending.