### PR TITLE
[T2D-005] Add Rhubarb recognizer selection

### DIFF
--- a/toonz/sources/toonz/autolipsyncpopup.cpp
+++ b/toonz/sources/toonz/autolipsyncpopup.cpp
@@ -214,6 +214,12 @@ AutoLipSyncPopup::AutoLipSyncPopup()
   m_otherLabel  = new QLabel(tr("C D G K N R S Th Y Z"));
   m_startAt     = new DVGui::IntLineEdit(this, 0);
   m_restToEnd   = new QCheckBox(tr("Extend Rest Drawing to End Marker"), this);
+  m_recognizerLabel = new QLabel(tr("Recognizer:"), this);
+  m_recognizer      = new QComboBox(this);
+  m_recognizer->addItem(tr("PocketSphinx (English)"), "pocketsphinx");
+  m_recognizer->addItem(tr("Phonetic"), "phonetic");
+  m_recognizerLabel->hide();
+  m_recognizer->hide();
 
   QImage placeHolder(160, 90, QImage::Format_ARGB32);
   placeHolder.fill(Qt::white);
@@ -413,6 +419,8 @@ AutoLipSyncPopup::AutoLipSyncPopup()
   m_insertAtLabel = new QLabel(tr("Insert at Frame: "));
   insertAtLay->addWidget(m_insertAtLabel);
   insertAtLay->addWidget(m_startAt);
+  insertAtLay->addWidget(m_recognizerLabel);
+  insertAtLay->addWidget(m_recognizer);
   insertAtLay->addStretch();
   optionsLay->addLayout(insertAtLay);
   optionsLay->addWidget(m_restToEnd);
@@ -674,9 +682,13 @@ void AutoLipSyncPopup::refreshSoundLevels() {
   if (m_soundLevels->currentIndex() < m_soundLevels->count() - 1) {
     m_insertAtLabel->hide();
     m_startAt->hide();
+    m_recognizerLabel->show();
+    m_recognizer->show();
   } else {
     m_insertAtLabel->show();
     m_startAt->show();
+    m_recognizerLabel->hide();
+    m_recognizer->hide();
   }
 }
 
@@ -872,6 +884,8 @@ void AutoLipSyncPopup::runRhubarb() {
                                 ->getOutputProperties()
                                 ->getFrameRate());
   args << "--datFrameRate" << QString::number(frameRate) << "--machineReadable";
+  if (m_recognizer->currentData().toString() == "phonetic")
+    args << "-r" << "phonetic";
   args << m_audioPath;
 
   m_progressDialog->show();
@@ -944,9 +958,13 @@ void AutoLipSyncPopup::onLevelChanged(int index) {
   if (level >= 0) {
     m_insertAtLabel->hide();
     m_startAt->hide();
+    m_recognizerLabel->show();
+    m_recognizer->show();
   } else {
     m_insertAtLabel->show();
     m_startAt->show();
+    m_recognizerLabel->hide();
+    m_recognizer->hide();
   }
 
   stopAllSound();

--- a/toonz/sources/toonz/autolipsyncpopup.h
+++ b/toonz/sources/toonz/autolipsyncpopup.h
@@ -83,6 +83,8 @@ class AutoLipSyncPopup final : public DVGui::Dialog {
   QLabel *m_scriptLabel;
   QLabel *m_columnLabel;
   QLabel *m_insertAtLabel;
+  QLabel *m_recognizerLabel;
+  QComboBox *m_recognizer;
   bool m_deleteFile = false;
   DVGui::ProgressDialog *m_progressDialog;
   QProcess *m_rhubarb;


### PR DESCRIPTION
## Summary
- add PocketSphinx and Phonetic recognizer choices to Auto Lip Sync for soundtrack sources
- pass Rhubarb the `-r phonetic` option when Phonetic is selected
- retain the existing external-file insertion workflow and asynchronous Rhubarb processing

## Validation
- `git diff --check`
- compiled `autolipsyncpopup.cpp` and generated `moc_autolipsyncpopup.cpp`

Manual Auto Lip Sync verification is pending.