### PR TITLE
[T2D-006] Add output name suffix options

### DIFF
--- a/toonz/sources/include/toutputproperties.h
+++ b/toonz/sources/include/toutputproperties.h
@@ -71,6 +71,8 @@ Can set in output to all levels, only selectecd levels or only animated levels.
 
   enum MaxTileSizeValues { LargeVal = 50, MediumVal = 10, SmallVal = 2 };
 
+  enum AppendVersionFormat { None = 0, Sequence, Timestamp };
+
 private:
   TFilePath m_path;
 
@@ -103,6 +105,8 @@ private:
   bool m_syncColorSettings;
   // for restoring bpp when setting the color space back to nonlinear
   int m_nonlinearBpp;
+
+  AppendVersionFormat m_appendVersionFormat;
 
 public:
   /*!
@@ -239,6 +243,13 @@ machine's CPU).
   void syncColorSettings(bool sync) { m_syncColorSettings = sync; }
   int getNonlinearBpp() { return m_nonlinearBpp; }
   void setNonlinearBpp(int bpp) { m_nonlinearBpp = bpp; }
+
+  AppendVersionFormat getAppendVersionFormat() const {
+    return m_appendVersionFormat;
+  }
+  void setAppendVersionFormat(AppendVersionFormat format) {
+    m_appendVersionFormat = format;
+  }
 };
 
 //--------------------------------------------

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -52,6 +52,9 @@
 #include <QPropertyAnimation>
 #include <QSpacerItem>
 #include <QEvent>
+#include <QAbstractButton>
+#include <QButtonGroup>
+#include <QRadioButton>
 //-----------------------------------------------------------------------------
 namespace {
 
@@ -179,6 +182,7 @@ OutputSettingsPopup::OutputSettingsPopup(bool isPreview)
     , m_subcameraChk(nullptr)
     , m_applyShrinkChk(nullptr)
     , m_outputCameraOm(nullptr)
+    , m_appendVersionFormatBG(nullptr)
     , m_isPreviewSettings(isPreview)
     , m_allowMT(Preferences::instance()->getFfmpegMultiThread())
     , m_presetCombo(nullptr)
@@ -604,6 +608,22 @@ QFrame *OutputSettingsPopup::createFileSettingsBox(bool isPreview) {
     m_channelWidthOm->installEventFilter(this);
     m_threadsComboOm->installEventFilter(this);
     m_rasterGranularityOm->installEventFilter(this);
+
+    m_appendVersionFormatBG = new QButtonGroup(this);
+    const auto addFormatButton = [this](const QString &text,
+                                        TOutputProperties::AppendVersionFormat
+                                            format) {
+      QRadioButton *button = new QRadioButton(text, this);
+      m_appendVersionFormatBG->addButton(button, static_cast<int>(format));
+      return button;
+    };
+
+    addFormatButton(tr("None"), TOutputProperties::None);
+    addFormatButton(tr("Sequence"), TOutputProperties::Sequence);
+    addFormatButton(tr("Timestamp"), TOutputProperties::Timestamp);
+    const int format = static_cast<int>(getProperties()->getAppendVersionFormat());
+    if (QAbstractButton *button = m_appendVersionFormatBG->button(format))
+      button->setChecked(true);
   }
 
   //-----
@@ -633,6 +653,20 @@ QFrame *OutputSettingsPopup::createFileSettingsBox(bool isPreview) {
       upperGridLay->setColumnStretch(1, 1);
 
       lay->addLayout(upperGridLay);
+
+      QGridLayout *versionGridLay = new QGridLayout();
+      versionGridLay->setContentsMargins(0, 0, 0, 0);
+      versionGridLay->setHorizontalSpacing(5);
+      versionGridLay->setVerticalSpacing(10);
+      versionGridLay->addWidget(new QLabel(tr("Append to Name:"), this), 0, 0,
+                                Qt::AlignRight | Qt::AlignVCenter);
+      for (int format = TOutputProperties::None;
+           format <= TOutputProperties::Timestamp; ++format) {
+        versionGridLay->addWidget(m_appendVersionFormatBG->button(format), 0,
+                                  format + 1);
+      }
+      versionGridLay->setColumnStretch(4, 1);
+      lay->addLayout(versionGridLay);
     }
 
     QGridLayout *bottomGridLay = new QGridLayout();
@@ -677,6 +711,8 @@ QFrame *OutputSettingsPopup::createFileSettingsBox(bool isPreview) {
                   SLOT(onFormatChanged(const QString &)));
     ret = ret && connect(m_fileFormatButton, SIGNAL(pressed()), this,
                          SLOT(openSettingsPopup()));
+    ret = ret && connect(m_appendVersionFormatBG, SIGNAL(idClicked(int)), this,
+                         SLOT(onAppendVersionFormatChanged(int)));
   }
   ret = ret && connect(m_resampleBalanceOm, SIGNAL(currentIndexChanged(int)),
                        SLOT(onResampleChanged(int)));
@@ -950,6 +986,9 @@ void OutputSettingsPopup::updateField() {
     m_fileFormat->setCurrentIndex(
         m_fileFormat->findText(QString::fromStdString(path.getType())));
     m_multimediaOm->setCurrentIndex(prop->getMultimediaRendering());
+    if (QAbstractButton *button = m_appendVersionFormatBG->button(
+            static_cast<int>(prop->getAppendVersionFormat())))
+      button->setChecked(true);
   }
 
   // Refresh format if allow-multithread was toggled
@@ -1098,6 +1137,24 @@ void OutputSettingsPopup::onPathChanged() {
   prop->setPath(fp);
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
 
+  if (m_presetCombo) m_presetCombo->setCurrentIndex(0);
+}
+
+//-----------------------------------------------------------------------------
+/*! Set the current scene output name suffix format.
+ */
+void OutputSettingsPopup::onAppendVersionFormatChanged(int format) {
+  if (!getCurrentScene() || format < TOutputProperties::None ||
+      format > TOutputProperties::Timestamp)
+    return;
+
+  TOutputProperties *prop = getProperties();
+  const auto newFormat =
+      static_cast<TOutputProperties::AppendVersionFormat>(format);
+  if (prop->getAppendVersionFormat() == newFormat) return;
+
+  prop->setAppendVersionFormat(newFormat);
+  TApp::instance()->getCurrentScene()->setDirtyFlag(true);
   if (m_presetCombo) m_presetCombo->setCurrentIndex(0);
 }
 

--- a/toonz/sources/toonz/outputsettingspopup.h
+++ b/toonz/sources/toonz/outputsettingspopup.h
@@ -10,6 +10,7 @@
 #include <QLabel>
 // forward declaration
 class ToonzScene;
+class QButtonGroup;
 class QComboBox;
 class QScrollArea;
 class QListWidgetItem;
@@ -69,6 +70,7 @@ class OutputSettingsPopup : public DVGui::Dialog {
   DVGui::DoubleLineEdit *m_stereoShift;
   QComboBox *m_rasterGranularityOm;
   QComboBox *m_threadsComboOm;
+  QButtonGroup *m_appendVersionFormatBG;
   bool m_allowMT;
 
   DVGui::DoubleLineEdit *m_frameRateFld;
@@ -128,6 +130,7 @@ protected slots:
   void onMultimediaChanged(int mode);
   void onThreadsComboChanged(int type);
   void onRasterGranularityChanged(int type);
+  void onAppendVersionFormatChanged(int format);
   void onStereoChecked(int);
   void onStereoChanged();
   void onSyncColorSettingsChecked(int state);

--- a/toonz/sources/toonz/rendercommand.cpp
+++ b/toonz/sources/toonz/rendercommand.cpp
@@ -52,6 +52,8 @@
 // Qt includes
 #include <QObject>
 #include <QDesktopServices>
+#include <QDateTime>
+#include <QDir>
 #include <QUrl>
 #include <QRegularExpression>  // Added to replace QRegExp
 
@@ -60,6 +62,40 @@
 namespace {
 
 #include "bravomark.h"
+
+TFilePath appendVersionSequence(const TFilePath &fp) {
+  int sequence = 0;
+  TFilePathSet fileList;
+  const TFileType::Type type = TFileType::getInfo(fp);
+  const QString pattern =
+      ((type == TFileType::RASTER_IMAGE || type == TFileType::RASTER_LEVEL) &&
+       !fp.isFfmpegType()
+           ? "*.*.*."
+           : "*.*.") +
+      QString::fromStdString(fp.getType());
+  QDir directory(fp.getParentDir().getQString());
+  directory.setNameFilters(QStringList(pattern));
+  TSystem::readDirectory(fileList, directory, false);
+
+  for (const TFilePath &file : fileList) {
+    bool isNumber = false;
+    const int currentSequence =
+        QString::fromStdString(file.getName()).section('.', 1, 1).toInt(
+            &isNumber);
+    if (isNumber && currentSequence > sequence) sequence = currentSequence;
+  }
+
+  const QString suffix = QString("%1").arg(sequence + 1, 4, 10, QChar('0'));
+  return fp.withName((QString::fromStdString(fp.getName()) + "." + suffix)
+                         .toStdWString());
+}
+
+TFilePath appendVersionTimestamp(const TFilePath &fp) {
+  const QString suffix =
+      QDateTime::currentDateTime().toString("yyyyMMddThhmmss");
+  return fp.withName((QString::fromStdString(fp.getName()) + "." + suffix)
+                         .toStdWString());
+}
 
 TRaster32P loadLight() {
   static TRaster32P ras(137, 48);
@@ -301,6 +337,16 @@ sprop->getOutputProperties()->setRenderSettings(rso);*/
                                // settings) but consists of multiple frames
     fp = fp.withFrame(TFrameId::EMPTY_FRAME);
   fp = scene->decodeFilePath(fp);
+  switch (outputSettings.getAppendVersionFormat()) {
+  case TOutputProperties::Sequence:
+    fp = appendVersionSequence(fp);
+    break;
+  case TOutputProperties::Timestamp:
+    fp = appendVersionTimestamp(fp);
+    break;
+  case TOutputProperties::None:
+    break;
+  }
   if (!TFileStatus(fp.getParentDir()).doesExist()) {
     try {
       TFilePath parent = fp.getParentDir();

--- a/toonz/sources/toonzlib/outputproperties.cpp
+++ b/toonz/sources/toonzlib/outputproperties.cpp
@@ -43,7 +43,8 @@ TOutputProperties::TOutputProperties()
     , m_subcameraPreview(false)
     , m_boardSettings(new BoardSettings())
     , m_formatTemplateFId()
-    , m_syncColorSettings(true) {
+    , m_syncColorSettings(true)
+    , m_appendVersionFormat(None) {
   m_renderSettings = new TRenderSettings();
   m_nonlinearBpp   = m_renderSettings->m_bpp;
 }
@@ -67,7 +68,8 @@ TOutputProperties::TOutputProperties(const TOutputProperties &src)
     , m_boardSettings(new BoardSettings(*src.m_boardSettings))
     , m_formatTemplateFId(src.m_formatTemplateFId)
     , m_syncColorSettings(src.m_syncColorSettings)
-    , m_nonlinearBpp(src.m_nonlinearBpp) {
+    , m_nonlinearBpp(src.m_nonlinearBpp)
+    , m_appendVersionFormat(src.m_appendVersionFormat) {
   std::map<std::string, TPropertyGroup *>::iterator ft,
       fEnd = m_formatProperties.end();
   for (ft = m_formatProperties.begin(); ft != fEnd; ++ft) {
@@ -115,6 +117,7 @@ TOutputProperties &TOutputProperties::operator=(const TOutputProperties &src) {
   m_boardSettings = new BoardSettings(*src.m_boardSettings);
 
   m_formatTemplateFId = src.m_formatTemplateFId;
+  m_appendVersionFormat = src.m_appendVersionFormat;
 
   return *this;
 }

--- a/toonz/sources/toonzlib/sceneproperties.cpp
+++ b/toonz/sources/toonzlib/sceneproperties.cpp
@@ -253,6 +253,8 @@ void TSceneProperties::saveData(TOStream &os) const {
     os.child("applyShrinkToViewer") << (rs.m_applyShrinkToViewer ? 1 : 0);
     os.child("fps") << out.getFrameRate();
     os.child("path") << outPath;
+    os.child("appendVersionFormat") <<
+        static_cast<int>(out.getAppendVersionFormat());
     os.child("bpp") << rs.m_bpp;
     if (rs.m_linearColorSpace) {
       os.child("linearColorSpace") << (rs.m_linearColorSpace ? 1 : 0);
@@ -548,6 +550,13 @@ void TSceneProperties::loadData(TIStream &is, bool isLoadingProject) {
               if (ext == "avi" && pg->getPropertyCount() != 1)
                 fp = fp.withType("tif");
               out.setPath(fp);
+            } else if (tagName == "appendVersionFormat") {
+              int format;
+              is >> format;
+              if (format >= TOutputProperties::None &&
+                  format <= TOutputProperties::Timestamp)
+                out.setAppendVersionFormat(
+                    static_cast<TOutputProperties::AppendVersionFormat>(format));
             } else if (tagName == "offset") {
               int j;
               is >> j;


### PR DESCRIPTION
## Summary
- add None, Sequence, and Timestamp choices to Output Settings
- append the selected suffix to main render destination names
- store the selected choice with scene output properties

## Validation
- `git diff --check`
- configured with CMake
- compiled the changed C++ sources and generated Qt meta-object source

Manual Output Settings, rendered-name, and scene-reload verification is pending.