### PR TITLE
[T2D-007] Sync output range with play range

### DIFF
--- a/toonz/sources/include/toutputproperties.h
+++ b/toonz/sources/include/toutputproperties.h
@@ -104,6 +104,8 @@ private:
   // for restoring bpp when setting the color space back to nonlinear
   int m_nonlinearBpp;
 
+  bool m_syncWithPlayRange;
+
 public:
   /*!
 Constructs TOutputProperties with default value.
@@ -239,6 +241,11 @@ machine's CPU).
   void syncColorSettings(bool sync) { m_syncColorSettings = sync; }
   int getNonlinearBpp() { return m_nonlinearBpp; }
   void setNonlinearBpp(int bpp) { m_nonlinearBpp = bpp; }
+
+  bool isSyncWithPlayRangeEnabled() const { return m_syncWithPlayRange; }
+  void setSyncWithPlayRangeEnabled(bool enabled) {
+    m_syncWithPlayRange = enabled;
+  }
 };
 
 //--------------------------------------------

--- a/toonz/sources/toonz/outputsettingspopup.cpp
+++ b/toonz/sources/toonz/outputsettingspopup.cpp
@@ -179,6 +179,7 @@ OutputSettingsPopup::OutputSettingsPopup(bool isPreview)
     , m_subcameraChk(nullptr)
     , m_applyShrinkChk(nullptr)
     , m_outputCameraOm(nullptr)
+    , m_syncWithPlayRange(nullptr)
     , m_isPreviewSettings(isPreview)
     , m_allowMT(Preferences::instance()->getFfmpegMultiThread())
     , m_presetCombo(nullptr)
@@ -380,6 +381,8 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
     cameraParametersBox->setObjectName("OutputSettingsCameraBox");
     m_outputCameraOm->setFocusPolicy(Qt::StrongFocus);
     m_outputCameraOm->installEventFilter(this);
+    m_syncWithPlayRange =
+        new DVGui::CheckBox(tr("Sync with Play Range"), this);
   } else {
     // Subcamera checkbox
     m_subcameraChk = new DVGui::CheckBox(tr("Use Sub-Camera"));
@@ -436,6 +439,12 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
       frameShrinkLay->addWidget(new QLabel(tr("Step:"), this), 0, 6,
                                 Qt::AlignRight | Qt::AlignVCenter);
       frameShrinkLay->addWidget(m_stepFld, 0, 7);
+      if (!isPreview) {
+        frameShrinkLay->addItem(
+            new QSpacerItem(10, 1, QSizePolicy::Fixed, QSizePolicy::Fixed),
+            0, 8);
+        frameShrinkLay->addWidget(m_syncWithPlayRange, 0, 9);
+      }
 
       frameShrinkLay->addWidget(new QLabel(tr("Shrink:"), this), 1, 0,
                                 Qt::AlignRight | Qt::AlignVCenter);
@@ -445,7 +454,7 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
         frameShrinkLay->addWidget(m_applyShrinkChk, 1, 4, 1, 5,
                                   Qt::AlignRight | Qt::AlignVCenter);
     }
-    frameShrinkLay->setColumnStretch(8, 1);
+    frameShrinkLay->setColumnStretch(10, 1);
 
     lay->addLayout(frameShrinkLay);
   }
@@ -468,6 +477,8 @@ QFrame *OutputSettingsPopup::createCameraSettingsBox(bool isPreview) {
   if (!isPreview) {
     ret = ret && connect(m_cameraSettings, SIGNAL(changed()), this,
                          SLOT(onCameraSettingsChanged()));
+    ret = ret && connect(m_syncWithPlayRange, SIGNAL(stateChanged(int)), this,
+                         SLOT(onSyncWithPlayRangeChanged(int)));
   } else {
     ret = ret && connect(m_applyShrinkChk, SIGNAL(stateChanged(int)),
                          SLOT(onApplyShrinkChecked(int)));
@@ -930,6 +941,7 @@ void OutputSettingsPopup::updateField() {
     m_rasterGranularityOm->setCurrentIndex(0);
 
     if (m_subcameraChk) m_subcameraChk->setCheckState(Qt::Unchecked);
+    if (m_syncWithPlayRange) m_syncWithPlayRange->setCheckState(Qt::Unchecked);
     m_linearColorSpaceChk->setCheckState(Qt::Unchecked);
     m_colorSpaceGammaFld->setText(QString());
     if (m_syncColorSettingsButton)
@@ -950,6 +962,7 @@ void OutputSettingsPopup::updateField() {
     m_fileFormat->setCurrentIndex(
         m_fileFormat->findText(QString::fromStdString(path.getType())));
     m_multimediaOm->setCurrentIndex(prop->getMultimediaRendering());
+    m_syncWithPlayRange->setChecked(prop->isSyncWithPlayRangeEnabled());
   }
 
   // Refresh format if allow-multithread was toggled
@@ -1316,6 +1329,35 @@ void OutputSettingsPopup::onSyncColorSettingsChecked(int state) {
   }
   // dirty flag will be set here
   TApp::instance()->getCurrentScene()->notifySceneChanged();
+}
+
+//----------------------------------------------
+
+void OutputSettingsPopup::onSyncWithPlayRangeChanged(int state) {
+  ToonzScene *scene = getCurrentScene();
+  if (!scene) return;
+
+  TOutputProperties *output = scene->getProperties()->getOutputProperties();
+  const bool enabled         = state == Qt::Checked;
+  bool changed = output->isSyncWithPlayRangeEnabled() != enabled;
+  output->setSyncWithPlayRangeEnabled(enabled);
+
+  if (enabled) {
+    int from, to, step;
+    TOutputProperties *preview = scene->getProperties()->getPreviewProperties();
+    if (preview->getRange(from, to, step)) {
+      int oldFrom, oldTo, oldStep;
+      output->getRange(oldFrom, oldTo, oldStep);
+      if (from != oldFrom || to != oldTo || step != oldStep) {
+        output->setRange(from, to, step);
+        changed = true;
+      }
+    }
+  }
+
+  if (changed) TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+  TApp::instance()->getCurrentScene()->notifySceneChanged();
+  if (m_presetCombo) m_presetCombo->setCurrentIndex(0);
 }
 
 //----------------------------------------------

--- a/toonz/sources/toonz/outputsettingspopup.h
+++ b/toonz/sources/toonz/outputsettingspopup.h
@@ -64,6 +64,7 @@ class OutputSettingsPopup : public DVGui::Dialog {
   QComboBox *m_dominantFieldOm;
   DVGui::CheckBox *m_applyShrinkChk;
   DVGui::CheckBox *m_subcameraChk;
+  DVGui::CheckBox *m_syncWithPlayRange;
   DVGui::DoubleLineEdit *m_stretchFromFld, *m_stretchToFld;
   DVGui::CheckBox *m_doStereoscopy;
   DVGui::DoubleLineEdit *m_stereoShift;
@@ -116,6 +117,7 @@ protected slots:
   void openSettingsPopup();
   void onCameraChanged(const QString &str);
   void onFrameFldEditFinished();
+  void onSyncWithPlayRangeChanged(int state);
   void onResampleChanged(int type);
   void onChannelWidthChanged(int type);
   void onLinearColorSpaceClicked(bool checked);

--- a/toonz/sources/toonz/xsheetdragtool.cpp
+++ b/toonz/sources/toonz/xsheetdragtool.cpp
@@ -272,6 +272,8 @@ void XsheetGUI::setPlayRange(int r0, int r1, int step, bool withUndo) {
   }
   ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
   scene->getProperties()->getPreviewProperties()->setRange(r0, r1, step);
+  TOutputProperties *output = scene->getProperties()->getOutputProperties();
+  if (output->isSyncWithPlayRangeEnabled()) output->setRange(r0, r1, step);
   TApp::instance()->getCurrentScene()->notifySceneChanged();
 }
 

--- a/toonz/sources/toonzlib/outputproperties.cpp
+++ b/toonz/sources/toonzlib/outputproperties.cpp
@@ -43,7 +43,8 @@ TOutputProperties::TOutputProperties()
     , m_subcameraPreview(false)
     , m_boardSettings(new BoardSettings())
     , m_formatTemplateFId()
-    , m_syncColorSettings(true) {
+    , m_syncColorSettings(true)
+    , m_syncWithPlayRange(false) {
   m_renderSettings = new TRenderSettings();
   m_nonlinearBpp   = m_renderSettings->m_bpp;
 }
@@ -67,7 +68,8 @@ TOutputProperties::TOutputProperties(const TOutputProperties &src)
     , m_boardSettings(new BoardSettings(*src.m_boardSettings))
     , m_formatTemplateFId(src.m_formatTemplateFId)
     , m_syncColorSettings(src.m_syncColorSettings)
-    , m_nonlinearBpp(src.m_nonlinearBpp) {
+    , m_nonlinearBpp(src.m_nonlinearBpp)
+    , m_syncWithPlayRange(src.m_syncWithPlayRange) {
   std::map<std::string, TPropertyGroup *>::iterator ft,
       fEnd = m_formatProperties.end();
   for (ft = m_formatProperties.begin(); ft != fEnd; ++ft) {
@@ -115,6 +117,7 @@ TOutputProperties &TOutputProperties::operator=(const TOutputProperties &src) {
   m_boardSettings = new BoardSettings(*src.m_boardSettings);
 
   m_formatTemplateFId = src.m_formatTemplateFId;
+  m_syncWithPlayRange = src.m_syncWithPlayRange;
 
   return *this;
 }

--- a/toonz/sources/toonzlib/sceneproperties.cpp
+++ b/toonz/sources/toonzlib/sceneproperties.cpp
@@ -253,6 +253,7 @@ void TSceneProperties::saveData(TOStream &os) const {
     os.child("applyShrinkToViewer") << (rs.m_applyShrinkToViewer ? 1 : 0);
     os.child("fps") << out.getFrameRate();
     os.child("path") << outPath;
+    os.child("syncWithPlayRange") << (out.isSyncWithPlayRangeEnabled() ? 1 : 0);
     os.child("bpp") << rs.m_bpp;
     if (rs.m_linearColorSpace) {
       os.child("linearColorSpace") << (rs.m_linearColorSpace ? 1 : 0);
@@ -548,6 +549,10 @@ void TSceneProperties::loadData(TIStream &is, bool isLoadingProject) {
               if (ext == "avi" && pg->getPropertyCount() != 1)
                 fp = fp.withType("tif");
               out.setPath(fp);
+            } else if (tagName == "syncWithPlayRange") {
+              int enabled;
+              is >> enabled;
+              out.setSyncWithPlayRangeEnabled(enabled != 0);
             } else if (tagName == "offset") {
               int j;
               is >> j;


### PR DESCRIPTION
## Summary
- add a per-scene Sync with Play Range option in Output Settings
- immediately adopt the active play range when the option is enabled
- mirror later play-range changes into the main output range
- save the setting with scene output properties

## Validation
- `git diff --check`
- configured with CMake
- compiled the changed C++ sources and generated Qt meta-object source

Manual Output Settings, marker, undo/redo, and scene-reload verification is pending.