### PR TITLE
[T2D-011] Add tool widget scale preference

### DIFF
--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -366,6 +366,7 @@ public:
   int getTempToolSwitchTimer() const {
     return getIntValue(tempToolSwitchTimer);
   }
+  bool isToolScaled() const { return getBoolValue(toolScale); }
   double getAnimateToolHandleSize() const {
     return getDoubleValue(animateToolHandleSize);
   }

--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -126,6 +126,7 @@ enum PreferencesItemId {
   useStrokeEndCursor,
   clickTwiceToCreateArcs,
   tempToolSwitchTimer,
+  toolScale,
   animateToolHandleSize,
   animateToolColor,
 

--- a/toonz/sources/tnztools/controlpointeditortool.cpp
+++ b/toonz/sources/tnztools/controlpointeditortool.cpp
@@ -19,6 +19,7 @@
 #include "toonz/tobjecthandle.h"
 #include "toonz/stage2.h"
 #include "toonz/tstageobject.h"
+#include "toonz/preferences.h"
 
 #include <QKeyEvent>
 
@@ -301,7 +302,8 @@ void ControlPointEditorTool::drawControlPoint() {
   TPixel color_handle   = TPixel(96, 64, 201);
   int controlPointCount = m_controlPointEditorStroke.getControlPointCount();
 
-  double pix    = getPixelSize() * 2.0f;
+  const double toolScale = Preferences::instance()->isToolScaled() ? 1.5 : 1.0;
+  double pix            = getPixelSize() * 2.0 * toolScale;
   double pix1_5 = 1.5 * pix, pix2 = pix + pix, pix2_5 = pix1_5 + pix,
          pix3 = pix2 + pix, pix3_5 = pix2_5 + pix, pix4 = pix3 + pix;
 

--- a/toonz/sources/tnztools/selectiontool.cpp
+++ b/toonz/sources/tnztools/selectiontool.cpp
@@ -10,6 +10,7 @@
 #include "tools/cursors.h"
 #include "toonz/stage2.h"
 #include "toonz/tobjecthandle.h"
+#include "toonz/preferences.h"
 
 #include <QKeyEvent>
 
@@ -953,7 +954,8 @@ void SelectionTool::updateAction(TPointD pos, const TMouseEvent &e) {
 
   FourPoints bbox = getBBox();
 
-  double pixelSize = getPixelSize();
+  const double toolScale = Preferences::instance()->isToolScaled() ? 2.0 : 1.0;
+  double pixelSize       = getPixelSize() * toolScale;
   if (!bbox.isEmpty()) {
     double maxDist  = 17 * pixelSize;
     double maxDist2 = maxDist * maxDist;
@@ -1249,7 +1251,8 @@ void SelectionTool::drawCommandHandle(const TImage *image) {
 
   if (!isSelectionEditable()) return;
 
-  double pixelSize = getPixelSize();
+  const double toolScale = Preferences::instance()->isToolScaled() ? 2.0 : 1.0;
+  double pixelSize       = getPixelSize() * toolScale;
   if (!isLevelType() && !isSelectedFramesType()) {
     TPointD c = getCenter() + TPointD(-pixelSize, +pixelSize);
 

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -1329,6 +1329,8 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
        tr("Geometric Tool: Click Twice to Create Arcs")},
       {tempToolSwitchTimer,
        tr("Switch Tool Temporarily Keypress Length (ms):")},
+      {toolScale,
+       tr("Increase Selection and Control Point Editor Tool Widget Size")},
       {animateToolHandleSize, tr("Handle Size (%):")},
       {animateToolColor, tr("Handle Color:")},
 
@@ -2123,6 +2125,7 @@ QWidget* PreferencesPopup::createToolsPage() {
   insertUI(useCtrlAltToResizeBrush, lay);
   insertUI(clickTwiceToCreateArcs, lay);
   insertUI(tempToolSwitchTimer, lay);
+  insertUI(toolScale, lay);
 
   QGridLayout* animateToolLay = insertGroupBox(tr("Animate Tool"), lay);
   {

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -570,6 +570,7 @@ void Preferences::definePreferenceItems() {
          true);
   define(tempToolSwitchTimer, "tempToolSwitchTimer", QMetaType::Int, 500, 1,
          std::numeric_limits<int>::max());
+  define(toolScale, "toolScale", QMetaType::Bool, false);
   define(animateToolHandleSize, "animateToolHandleSize", QMetaType::Double, 1.0,
          1.0, 5.0);
   define(animateToolColor, "animateToolColor", QMetaType::QColor,


### PR DESCRIPTION
## Summary
- add a Tools preference for larger Selection and Control Point Editor handles
- scale Selection hit areas and visible handles together
- retain default handle sizes unless the preference is enabled

## Validation
- `git diff --check`
- configured with CMake
- compiled changed preference, Selection, and Control Point Editor sources

Manual preference and handle-size verification is pending.