### PR TITLE
Restore saved scene frame position

### DIFF
--- a/toonz/sources/include/toonz/toonzscene.h
+++ b/toonz/sources/include/toonz/toonzscene.h
@@ -265,6 +265,12 @@ If \b scene is in +scenes/name.tnz return name,
   bool isLoading() { return m_isLoading; }
   void setIsLoading(bool isLoading) { m_isLoading = isLoading; }
 
+  int getStartRow() const { return m_startRow; }
+  void setStartRow(int startRow) { m_startRow = startRow; }
+
+  int getStartCol() const { return m_startCol; }
+  void setStartCol(int startCol) { m_startCol = startCol; }
+
 private:
   TFilePath m_scenePath;  //!< Full path to the scene file (.tnz).
 
@@ -286,6 +292,9 @@ private:
                      // is used when loading PSD levels, for defining whether to
                      // convert a layerId in the path to the layer name. See
                      // TXshSimpleLevel::load().
+
+  int m_startRow;
+  int m_startCol;
 
 private:
   // noncopyable

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1516,6 +1516,8 @@ bool IoCmd::saveScene(const TFilePath &path, int flags) {
 
   TApp::instance()->setSaveInProgress(true);
   try {
+    scene->setStartRow(app->getCurrentFrame()->getFrameIndex());
+    scene->setStartCol(app->getCurrentColumn()->getColumnIndex());
     scene->save(scenePath, xsheet);
   } catch (const TSystemException &se) {
     DVGui::warning(QString::fromStdWString(se.getMessage()));
@@ -2019,8 +2021,8 @@ bool IoCmd::loadScene(const TFilePath &path, bool updateRecentFile,
   }
   app->getCurrentScene()->setScene(scene);
   app->getCurrentScene()->notifyNameSceneChange();
-  app->getCurrentFrame()->setFrame(0);
-  app->getCurrentColumn()->setColumnIndex(0);
+  app->getCurrentFrame()->setFrame(scene->getStartRow());
+  app->getCurrentColumn()->setColumnIndex(scene->getStartCol());
 
   app->getCurrentXsheet()->notifyXsheetSoundChanged();
   app->getCurrentObject()->setIsSpline(false);

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -277,7 +277,11 @@ static void deleteAllUntitledScenes() {
 // ToonzScene
 
 ToonzScene::ToonzScene()
-    : m_contentHistory(0), m_isUntitled(true), m_isLoading(false) {
+    : m_contentHistory(0)
+    , m_isUntitled(true)
+    , m_isLoading(false)
+    , m_startRow(0)
+    , m_startCol(0) {
   m_childStack = new ChildStack(this);
   m_properties = new TSceneProperties();
   m_levelSet   = new TLevelSet();
@@ -485,9 +489,19 @@ void ToonzScene::loadTnzFile(const TFilePath &fp) {
               m_levelSet->insertLevel(xshLevel);
             }
           }
-        } else if (tagName == "xsheet")
+        } else if (tagName == "xsheet") {
+          bool isValidStartRow = false;
+          int startRow = QString::fromStdString(is.getTagAttribute("startRow"))
+                             .toInt(&isValidStartRow);
+          if (isValidStartRow && startRow >= 0) m_startRow = startRow;
+
+          bool isValidStartCol = false;
+          int startCol = QString::fromStdString(is.getTagAttribute("startCol"))
+                             .toInt(&isValidStartCol);
+          if (isValidStartCol && startCol >= 0) m_startCol = startCol;
+
           is >> *getXsheet();
-        else if (tagName == "history") {
+        } else if (tagName == "history") {
           std::string historyData, s;
           while (!is.eos()) {
             is >> s;
@@ -656,7 +670,10 @@ void ToonzScene::save(const TFilePath &fp, TXsheet *subxsh) {
     std::set<TXshLevel *> emptySaveSet;
     m_levelSet->setSaveSet(emptySaveSet);
 
-    os.openChild("xsheet");
+    attr.clear();
+    attr["startRow"] = std::to_string(m_startRow);
+    attr["startCol"] = std::to_string(m_startCol);
+    os.openChild("xsheet", attr);
     os << *xsh;
     os.closeChild();
 


### PR DESCRIPTION
## Summary
- save the active Xsheet frame and column with scene data
- restore the saved position when a scene is loaded
- retain frame and column zero for older or malformed scene attributes

## Verification
- `git diff --check`
- compiled `toonzscene.cpp` and `iocommand.cpp` against the configured OpenToonz build