### PR TITLE
Add Current Drawing on Top view mode

### DIFF
--- a/toonz/sources/include/toonz/stageplayer.h
+++ b/toonz/sources/include/toonz/stageplayer.h
@@ -113,6 +113,7 @@ public:
   static bool m_isShiftAndTraceEnabled;
 
   TPixel32 m_filterColor;
+  bool m_currentDrawingOnTop;
 
 public:
   Player();

--- a/toonz/sources/include/toonz/stagevisitor.h
+++ b/toonz/sources/include/toonz/stagevisitor.h
@@ -138,6 +138,7 @@ struct DVAPI VisitArgs {
   int m_isGuidedDrawingEnabled;
   int m_guidedFrontStroke;
   int m_guidedBackStroke;
+  bool m_currentDrawingOnTop;
 #if defined(x64)
   TRasterImageP m_liveViewImage = 0;
   TRasterImageP m_lineupImage   = 0;
@@ -160,7 +161,8 @@ public:
       , m_isGuidedDrawingEnabled(0)
       , m_guidedFrontStroke(-1)
       , m_guidedBackStroke(-1)
-      , m_rasterizePli(false) {}
+      , m_rasterizePli(false)
+      , m_currentDrawingOnTop(false) {}
 };
 
 //=============================================================================

--- a/toonz/sources/include/toonz/txsheet.h
+++ b/toonz/sources/include/toonz/txsheet.h
@@ -160,6 +160,7 @@ private:
   TXshColumnP m_cameraColumn;  //!< Smart pointer – ref‑counted
 
   TXsheetColumnChangeObserver *m_observer;
+  bool m_currentDrawingOnTop;
 
   DECLARE_CLASS_CODE
 
@@ -169,6 +170,9 @@ public:
 
   //! Returns a unique identifier associated with the xsheet instance.
   unsigned long id() const;
+
+  bool isCurrentDrawingOnTop() const { return m_currentDrawingOnTop; }
+  void setCurrentDrawingOnTop(bool onTop) { m_currentDrawingOnTop = onTop; }
 
   /*! Returns max frame number used in xsheet.
           \sa getMaxFrame()

--- a/toonz/sources/toonz/icons/dark/actions/16x16/current_on_top.svg
+++ b/toonz/sources/toonz/icons/dark/actions/16x16/current_on_top.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16px"
+   height="16px"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg20"
+   sodipodi:docname="current_on_top.svg"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs24" /><sodipodi:namedview
+   id="namedview22"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:pageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   showgrid="true"
+   inkscape:snap-grids="false"
+   inkscape:zoom="44.9375"
+   inkscape:cx="8"
+   inkscape:cy="7.9888734"
+   inkscape:window-width="1920"
+   inkscape:window-height="1141"
+   inkscape:window-x="-7"
+   inkscape:window-y="-7"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="g18"><inkscape:grid
+     type="xygrid"
+     id="grid841" /></sodipodi:namedview>
+    <g
+   transform="matrix(1,0,0,1,-170,-210)"
+   id="g18">
+        <g
+   id="new_vector_level"
+   transform="matrix(1,0,0,1,60,-20)">
+            <g
+   id="bg"
+   transform="matrix(0.110345,0,0,0.121212,93.7793,211.091)">
+                <rect
+   x="147"
+   y="156"
+   width="145"
+   height="132"
+   style="fill:rgb(135,135,135);fill-opacity:0;"
+   id="rect2" />
+            </g>
+            <g
+   id="g11">
+                <g
+   transform="matrix(1,0,0,1,1,0)"
+   id="g7">
+                    <path
+   d="M120,231.5L123.5,235L120,235L120,231.5Z"
+   id="path5" />
+                </g>
+                <path
+   d="m 125,235 c 0,-0.265 -0.105,-0.52 -0.293,-0.707 l -3,-3 C 121.52,231.105 121.265,231 121,231 h -9 c -0.552,0 -1,0.448 -1,1 v 5 c 0,0.552 0.448,1 1,1 h 12 c 0.552,0 1,-0.448 1,-1 z m -1,0 -3,-3 h -9 v 5 h 12 z"
+   id="path9"
+   sodipodi:nodetypes="sccsssssssscccccc" />
+            </g>
+            <g
+   transform="matrix(1,0,0,1,108,227)"
+   id="g15">
+                
+            </g>
+        </g>
+    <rect
+   style="fill:#000000;stroke:#000000;stroke-width:1.24066;stroke-linecap:round;stroke-dashoffset:0.9"
+   id="rect3568"
+   width="12.880068"
+   height="0.75934029"
+   x="171.49828"
+   y="220.12033" /><rect
+   style="clip-rule:evenodd;fill:#000000;fill-rule:evenodd;stroke:#000000;stroke-width:1.24067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:2;stroke-dashoffset:0.9"
+   id="rect3568-5"
+   width="12.880322"
+   height="0.7593298"
+   x="171.51547"
+   y="223.62033" /></g>
+</svg>

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2468,6 +2468,8 @@ void MainWindow::defineActions() {
   createToggle(MI_VectorGuidedDrawing, QT_TR_NOOP("Vector Guided Drawing"), "",
                Preferences::instance()->isGuidedDrawingEnabled(),
                MenuViewCommandType, "view_guided_drawing");
+  createToggle(MI_CurrentDrawingOnTop, QT_TR_NOOP("Current Drawing On Top"),
+               "", false, MenuViewCommandType, "current_on_top");
   if (QGLPixelBuffer::hasOpenGLPbuffers())
     createToggle(MI_RasterizePli, QT_TR_NOOP("&Visualize Vector As Raster"), "",
                  RasterizePliToggleAction ? 1 : 0, MenuViewCommandType,

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -1437,6 +1437,8 @@ QMenuBar *StackedMenuBar::createFullMenuBar() {
   addMenuItem(viewMenu, MI_NoShift);
   addMenuItem(viewMenu, MI_ResetShift);
   viewMenu->addSeparator();
+  addMenuItem(viewMenu, MI_CurrentDrawingOnTop);
+  viewMenu->addSeparator();
   addMenuItem(viewMenu, MI_VectorGuidedDrawing);
   viewMenu->addSeparator();
   addMenuItem(viewMenu, MI_RasterizePli);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -476,6 +476,7 @@
 
 #define MI_VectorGuidedDrawing "MI_VectorGuidedDrawing"
 #define MI_OpenGuidedDrawingControls "MI_OpenGuidedDrawingControls"
+#define MI_CurrentDrawingOnTop "MI_CurrentDrawingOnTop"
 
 #define MI_SelectNextGuideStroke "MI_SelectNextGuideStroke"
 #define MI_SelectPrevGuideStroke "MI_SelectPrevGuideStroke"

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -491,6 +491,23 @@ public:
 } resetShiftTraceCommand;
 
 //-----------------------------------------------------------------------------
+
+class CurrentDrawingOnTopCommand final : public MenuItemHandler {
+public:
+  CurrentDrawingOnTopCommand()
+      : MenuItemHandler(MI_CurrentDrawingOnTop) {}
+
+  void execute() override {
+    QAction *action =
+        CommandManager::instance()->getAction(MI_CurrentDrawingOnTop);
+    TApp *app = TApp::instance();
+    app->getCurrentXsheet()->getXsheet()->setCurrentDrawingOnTop(
+        action && action->isChecked());
+    app->getCurrentXsheet()->notifyXsheetChanged();
+  }
+} currentDrawingOnTopCommand;
+
+//-----------------------------------------------------------------------------
 // Following commands (VB_***) are registered for command bar buttons.
 // They are separatd from the original visalization commands
 // so that they will not break a logic of ShortcutZoomer.
@@ -2187,6 +2204,8 @@ void SceneViewer::drawScene() {
     args.m_isGuidedDrawingEnabled = useGuidedDrawing;
     args.m_guidedFrontStroke      = guidedFrontStroke;
     args.m_guidedBackStroke       = guidedBackStroke;
+    args.m_currentDrawingOnTop =
+        app->getCurrentXsheet()->getXsheet()->isCurrentDrawingOnTop();
 
     // args.m_currentFrameId = app->getCurrentFrame()->getFid();
     Stage::visit(painter, args);
@@ -2250,6 +2269,8 @@ void SceneViewer::drawScene() {
       args.m_isGuidedDrawingEnabled = useGuidedDrawing;
       args.m_guidedFrontStroke      = guidedFrontStroke;
       args.m_guidedBackStroke       = guidedBackStroke;
+      args.m_currentDrawingOnTop =
+          app->getCurrentXsheet()->getXsheet()->isCurrentDrawingOnTop();
 
 #if defined(x64)
       if (m_stopMotion->m_alwaysUseLiveViewImages &&

--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -221,6 +221,7 @@
 		<file>icons/dark/actions/16x16/nextkey.svg</file>
 		<file>icons/dark/actions/16x16/prevkey.svg</file>
 		<file>icons/dark/actions/16x16/blankframes.svg</file>
+		<file>icons/dark/actions/16x16/current_on_top.svg</file>
 
 		<file>icons/dark/actions/16x16/snapshot.svg</file>
 		<file>icons/dark/actions/16x16/compare.svg</file>

--- a/toonz/sources/toonzlib/stage.cpp
+++ b/toonz/sources/toonzlib/stage.cpp
@@ -213,6 +213,7 @@ public:
   int m_isGuidedDrawingEnabled;
   int m_guidedFrontStroke = -1;
   int m_guidedBackStroke  = -1;
+  bool m_currentDrawingOnTop;
   std::vector<TXshColumn *> m_ancestors;
 
   const ImagePainter::VisualSettings *m_vs;
@@ -292,7 +293,8 @@ StageBuilder::StageBuilder()
     , m_editingShift(false)
     , m_showShiftOrigin(false)
     , m_currentXsheetLevel(0)
-    , m_xsheetLevel(0) {
+    , m_xsheetLevel(0)
+    , m_currentDrawingOnTop(false) {
   m_placementStack.push_back(ZPlacement());
 }
 
@@ -511,6 +513,10 @@ void StageBuilder::addCell(PlayerSet &players, ToonzScene *scene, TXsheet *xsh,
         }
       }
     }
+
+    player.m_currentDrawingOnTop = m_currentDrawingOnTop;
+    if (m_currentDrawingOnTop && player.m_isCurrentColumn)
+      player.m_bingoOrder = 10;
 
     players.push_back(player);
   } else if (TXshChildLevel *cl = xl->getChildLevel()) {
@@ -860,6 +866,7 @@ void StageBuilder::addSimpleLevelFrame(PlayerSet &players,
   player.m_isEditingLevel       = true;
   player.m_ancestorColumnIndex  = -1;
   player.m_dpiAff               = getDpiAffine(level, fid);
+  player.m_currentDrawingOnTop  = m_currentDrawingOnTop;
 }
 
 //-----------------------------------------------------------------------------
@@ -959,6 +966,7 @@ void Stage::visit(Visitor &visitor, const VisitArgs &args) {
   sb.m_isGuidedDrawingEnabled = args.m_isGuidedDrawingEnabled;
   sb.m_guidedFrontStroke      = args.m_guidedFrontStroke;
   sb.m_guidedBackStroke       = args.m_guidedBackStroke;
+  sb.m_currentDrawingOnTop    = args.m_currentDrawingOnTop;
 #if defined(x64)
   if (args.m_liveViewImage) {
     sb.m_liveViewImage  = args.m_liveViewImage;

--- a/toonz/sources/toonzlib/stageplayer.cpp
+++ b/toonz/sources/toonzlib/stageplayer.cpp
@@ -45,7 +45,8 @@ Stage::Player::Player()
     , m_frame(0)
     , m_isPlaying(false)
     , m_opacity(255)
-    , m_bingoOrder(0) {}
+    , m_bingoOrder(0)
+    , m_currentDrawingOnTop(false) {}
 
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/toonzlib/txsheet.cpp
+++ b/toonz/sources/toonzlib/txsheet.cpp
@@ -194,7 +194,8 @@ TXsheet::TXsheet()
     , m_soundProperties(std::make_unique<SoundProperties>())
     , m_navigationTags(std::make_unique<NavigationTags>())
     , m_cameraColumnIndex(0)
-    , m_observer(nullptr) {
+    , m_observer(nullptr)
+    , m_currentDrawingOnTop(false) {
   m_imp->m_handleManager = std::make_unique<XshHandleManager>(this);
   m_imp->m_pegTree->setHandleManager(m_imp->m_handleManager.get());
   m_imp->m_pegTree->createGrammar(this);


### PR DESCRIPTION
## Summary
- add a View-menu toggle that renders the current drawing above other columns
- pass the transient Xsheet setting through the scene visitor to compositing order
- preserve normal render ordering when disabled

## Verification
- `git diff --check`
- `xmllint --noout toonz/sources/toonz/toonz.qrc`
- compiled `sceneviewer.cpp`, `mainwindow.cpp`, `menubar.cpp`, `stage.cpp`, `stageplayer.cpp`, and `txsheet.cpp` against the configured OpenToonz build