### PR TITLE
Add scene overlay image support (DO NOT MERGE)

### DIFF
--- a/toonz/sources/include/toonz/sceneproperties.h
+++ b/toonz/sources/include/toonz/sceneproperties.h
@@ -99,6 +99,8 @@ private:
 
   bool m_columnColorFilterOnRender;
   TFilePath m_camCapSaveInPath;
+  TFilePath m_overlayFile;
+  int m_overlayOpacity;
 
 public:
   /*!
@@ -318,6 +320,13 @@ and height.
   // templateFId in preview settings is used for "input" file format
   // such as new raster level, captured images by camera capture feature, etc.
   TFrameId &formatTemplateFIdForInput();
+
+  TFilePath getOverlayFile() const { return m_overlayFile; }
+  void setOverlayFile(const TFilePath &overlayFile) {
+    m_overlayFile = overlayFile;
+  }
+  int getOverlayOpacity() const { return m_overlayOpacity; }
+  void setOverlayOpacity(int overlayOpacity) { m_overlayOpacity = overlayOpacity; }
 
 private:
   // not implemented

--- a/toonz/sources/include/toonz/toonzscene.h
+++ b/toonz/sources/include/toonz/toonzscene.h
@@ -34,6 +34,8 @@ class TXshLevel;
 class TXshSoundColumn;
 class TContentHistory;
 class LevelOptions;
+class TXshLevelColumn;
+class TLevelColumnFx;
 
 //========================================================================
 
@@ -265,6 +267,12 @@ If \b scene is in +scenes/name.tnz return name,
   bool isLoading() { return m_isLoading; }
   void setIsLoading(bool isLoading) { m_isLoading = isLoading; }
 
+  void loadOverlayFile(const TFilePath &overlayFile);
+  TXshLevel *getOverlayLevel();
+  int getOverlayOpacity() const { return m_overlayOpacity; }
+  void setOverlayOpacity(int opacity);
+  TLevelColumnFx *getOverlayFx(int row);
+
 private:
   TFilePath m_scenePath;  //!< Full path to the scene file (.tnz).
 
@@ -286,6 +294,12 @@ private:
                      // is used when loading PSD levels, for defining whether to
                      // convert a layerId in the path to the layer name. See
                      // TXshSimpleLevel::load().
+
+  bool m_overlayLoaded;
+  TXshLevel *m_overlayLevel;
+  int m_overlayOpacity;
+  TXshLevelColumn *m_overlayLevelColumn;
+  TLevelColumnFx *m_overlayFx;
 
 private:
   // noncopyable

--- a/toonz/sources/include/toonzqt/camerasettingswidget.h
+++ b/toonz/sources/include/toonzqt/camerasettingswidget.h
@@ -91,7 +91,7 @@ class DVAPI CameraSettingsWidget final : public QFrame {
 
   QPushButton *m_fspChk;  // Force Squared Pixel => dpix == dpiy
 
-  QPushButton *m_useLevelSettingsBtn;
+  QPushButton *m_useLevelSettingsBtn, *m_useOverlaySettingsBtn;
   QComboBox *m_presetListOm;
   QPushButton *m_addPresetBtn, *m_removePresetBtn;
 
@@ -100,7 +100,7 @@ class DVAPI CameraSettingsWidget final : public QFrame {
   QString m_presetListFile;
 
   // needed by "use level settings"
-  TXshSimpleLevel *m_currentLevel;
+  TXshSimpleLevel *m_currentLevel, *m_overlayLevel;
 
   void savePresetList();
   void loadPresetList();
@@ -129,6 +129,7 @@ public:
   // Defines the level referred by the button "Use level settings".
   // Calling setCurrentLevel(nullptr) disables the button
   void setCurrentLevel(TXshLevel *xshLevel);
+  void setOverlayLevel(TXshLevel *xshLevel);
 
   // camera => widget fields (i.e. initialize widget)
   void setFields(const TCamera *camera);
@@ -179,6 +180,7 @@ protected:
   void updatePresetListOm();
 
   void setArFld(double ar);
+  bool applyLevelSettings(TXshSimpleLevel *level);
 
 protected slots:
   void onLxChanged();
@@ -194,6 +196,7 @@ protected slots:
   void addPreset();
   void removePreset();
   void useLevelSettings();
+  void useOverlaySettings();
 
 signals:
   void changed();  // some value has been changed

--- a/toonz/sources/toonz/camerasettingspopup.cpp
+++ b/toonz/sources/toonz/camerasettingspopup.cpp
@@ -149,6 +149,7 @@ void CameraSettingsPopup::showEvent(QShowEvent *e) {
 
 void CameraSettingsPopup::hideEvent(QHideEvent *e) {
   m_cameraSettingsWidget->setCurrentLevel(0);
+  m_cameraSettingsWidget->setOverlayLevel(0);
 
   if (m_cameraId != TStageObjectId::NoneId) {
     // Remove the popup from currentlyOpened ones and schedule for deletion
@@ -249,6 +250,8 @@ void CameraSettingsPopup::updateFields() {
         TDimensionD(res.lx / Stage::standardDpi, res.ly / Stage::standardDpi));
   }
   if (camera) m_cameraSettingsWidget->setFields(camera);
+  m_cameraSettingsWidget->setOverlayLevel(
+      TApp::instance()->getCurrentScene()->getScene()->getOverlayLevel());
 }
 
 void CameraSettingsPopup::onLevelSwitched(TXshLevel *) {

--- a/toonz/sources/toonz/scenesettingspopup.cpp
+++ b/toonz/sources/toonz/scenesettingspopup.cpp
@@ -25,6 +25,8 @@
 
 // TnzCore includes
 #include "trop.h"
+#include "tsystem.h"
+#include "tlevel_io.h"
 
 // Qt includes
 #include <QLayout>
@@ -34,6 +36,7 @@
 #include <QMainWindow>
 #include <QPainter>
 #include <QPushButton>
+#include <QImageReader>
 
 using namespace DVGui;
 
@@ -507,6 +510,15 @@ SceneSettingsPopup::SceneSettingsPopup()
   QPushButton *editColorFiltersButton =
       new QPushButton(tr("Edit Column Color Filters"), this);
 
+  m_overlayFile = new DVGui::FileField(this);
+  m_overlayFile->setFileMode(QFileDialog::AnyFile);
+  QStringList filters;
+  for (const QByteArray &format : QImageReader::supportedImageFormats())
+    filters << format;
+  filters << "pli" << "tlv";
+  m_overlayFile->setFilters(filters);
+  m_overlayOpacity = new DVGui::IntLineEdit(this, 100, 0, 100);
+
   // layout
   QGridLayout *mainLayout = new QGridLayout();
   mainLayout->setContentsMargins(10, 10, 10, 10);
@@ -557,6 +569,13 @@ SceneSettingsPopup::SceneSettingsPopup()
                           Qt::AlignRight | Qt::AlignVCenter);
     mainLayout->addWidget(editCellMarksButton, 7, 1, 1, 4,
                           Qt::AlignLeft | Qt::AlignVCenter);
+    mainLayout->addWidget(new QLabel(tr("Overlay Image:"), this), 8, 0,
+                          Qt::AlignRight | Qt::AlignVCenter);
+    mainLayout->addWidget(m_overlayFile, 8, 1, 1, 4);
+    mainLayout->addWidget(new QLabel(tr("Overlay Opacity:"), this), 9, 0,
+                          Qt::AlignRight | Qt::AlignVCenter);
+    mainLayout->addWidget(m_overlayOpacity, 9, 1, 1, 4,
+                          Qt::AlignLeft | Qt::AlignVCenter);
   }
   mainLayout->setColumnStretch(0, 0);
   mainLayout->setColumnStretch(1, 0);
@@ -601,6 +620,10 @@ SceneSettingsPopup::SceneSettingsPopup()
   // Cell Marks
   ret = ret && connect(editCellMarksButton, SIGNAL(clicked()), this,
                        SLOT(onEditCellMarksButtonClicked()));
+  ret = ret && connect(m_overlayFile, SIGNAL(pathChanged()), this,
+                       SLOT(onOverlayFileChanged()));
+  ret = ret && connect(m_overlayOpacity, SIGNAL(editingFinished()), this,
+                       SLOT(onOverlayOpacityChanged()));
   assert(ret);
 }
 
@@ -657,6 +680,8 @@ void SceneSettingsPopup::update() {
 
   if (m_cellMarksPopup) m_cellMarksPopup->update();
   if (m_colorFiltersPopup) m_colorFiltersPopup->updateContents();
+  m_overlayFile->setPath(sprop->getOverlayFile().getQString());
+  m_overlayOpacity->setValue(100 * sprop->getOverlayOpacity() / 255);
 }
 
 //-----------------------------------------------------------------------------
@@ -769,6 +794,33 @@ void SceneSettingsPopup::onEditCellMarksButtonClicked() {
   if (!m_cellMarksPopup) m_cellMarksPopup = new CellMarksPopup(this);
   m_cellMarksPopup->show();
   m_cellMarksPopup->raise();
+}
+
+//-----------------------------------------------------------------------------
+
+void SceneSettingsPopup::onOverlayFileChanged() {
+  ToonzScene *scene = TApp::instance()->getCurrentScene()->getScene();
+  TSceneProperties *properties = getProperties();
+  TFilePath path(m_overlayFile->getPath());
+  if (!path.isEmpty() &&
+      !TSystem::doesExistFileOrLevel(scene->decodeFilePath(path))) {
+    m_overlayFile->setPath(properties->getOverlayFile().getQString());
+    return;
+  }
+
+  properties->setOverlayFile(path);
+  scene->loadOverlayFile(path);
+  TApp::instance()->getCurrentScene()->notifySceneChanged();
+}
+
+//-----------------------------------------------------------------------------
+
+void SceneSettingsPopup::onOverlayOpacityChanged() {
+  const int opacity = 255 * m_overlayOpacity->getValue() / 100;
+  TSceneProperties *properties = getProperties();
+  properties->setOverlayOpacity(opacity);
+  TApp::instance()->getCurrentScene()->getScene()->setOverlayOpacity(opacity);
+  TApp::instance()->getCurrentScene()->notifySceneChanged();
 }
 
 //=============================================================================

--- a/toonz/sources/toonz/scenesettingspopup.h
+++ b/toonz/sources/toonz/scenesettingspopup.h
@@ -9,6 +9,7 @@
 #include "toonzqt/doublefield.h"
 #include "toonzqt/colorfield.h"
 #include "toonzqt/checkbox.h"
+#include "toonzqt/filefield.h"
 
 // forward declaration
 class TSceneProperties;
@@ -78,6 +79,8 @@ class SceneSettingsPopup final : public QDialog {
   ColorFiltersPopup *m_colorFiltersPopup;
 
   DVGui::DoubleLineEdit *m_colorSpaceGammaFld;
+  DVGui::FileField *m_overlayFile;
+  DVGui::IntLineEdit *m_overlayOpacity;
 
 public:
   SceneSettingsPopup();
@@ -105,6 +108,8 @@ public slots:
 
   void onEditCellMarksButtonClicked();
   void onEditColorFiltersButtonClicked();
+  void onOverlayFileChanged();
+  void onOverlayOpacityChanged();
 };
 
 #endif  // SCENESETTINGSPOPUP_H

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -93,6 +93,7 @@
 
 TEnv::IntVar RotateOnCameraCenter("RotateOnCameraCenter", 0);
 TEnv::DoubleVar RotateAngle("RotateAngle", 90);
+TEnv::IntVar ShowSceneOverlay("ShowSceneOverlay", 1);
 
 void drawSpline(const TAffine &viewMatrix, const TRect &clipRect, bool camera3d,
                 double pixelSize);
@@ -1626,6 +1627,12 @@ void SceneViewer::drawCameraStand() {
   assert(glGetError() == GL_NO_ERROR);
   drawScene();
   assert((glGetError()) == GL_NO_ERROR);
+
+  if (fieldGuideToggle.getStatus() && ShowSceneOverlay) {
+    assert(glGetError() == GL_NO_ERROR);
+    drawSceneOverlay();
+    assert((glGetError()) == GL_NO_ERROR);
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -2334,6 +2341,76 @@ void SceneViewer::drawScene() {
     for (auto stroke : guidedStrokes) {
       m_guidedDrawingBBox += stroke->getBBox();
     }
+  }
+}
+
+//------------------------------------------------------------------------------
+
+void SceneViewer::drawSceneOverlay() {
+  TApp *app = TApp::instance();
+  if (app->getCurrentFrame()->isEditingLevel()) return;
+
+  ToonzScene *scene = app->getCurrentScene()->getScene();
+  TXshLevel *level   = scene->getOverlayLevel();
+  if (!level || !level->getSimpleLevel()) return;
+
+  TXshSimpleLevel *sl = level->getSimpleLevel();
+  const TFrameId frameId = sl->getFirstFid();
+  const TImageP image = TXshCell(sl, frameId).getImage(false);
+  TRasterImageP ri = image;
+  TToonzImageP ti  = image;
+  TVectorImageP vi = image;
+  if (!ri && !ti && !vi) return;
+
+  const int frame = app->getCurrentFrame()->getFrame();
+  TXsheet *xsh    = app->getCurrentXsheet()->getXsheet();
+  TRect clipRect   = getActualClipRect(getViewMatrix());
+  clipRect += TPoint(width() * 0.5, height() * 0.5);
+
+  TStageObject *camera = xsh->getStageObject(
+      xsh->getStageObjectTree()->getCurrentCameraId());
+  const TAffine viewAff =
+      getViewMatrix() * camera->getPlacement(frame) *
+      TScale((1000 + camera->getZ(frame)) / 1000);
+
+  Stage::Player player;
+  player.m_sl                     = sl;
+  player.m_frame                  = frame;
+  player.m_fid                    = frameId;
+  player.m_isCurrentColumn        = false;
+  player.m_isCurrentXsheetLevel   = true;
+  player.m_isEditingLevel         = true;
+  player.m_currentFrameId         = 0;
+  player.m_isGuidedDrawingEnabled = false;
+  player.m_guidedFrontStroke      = -1;
+  player.m_guidedBackStroke       = -1;
+  player.m_isVisibleinOSM         = false;
+  player.m_onionSkinDistance      = c_noOnionSkin;
+  player.m_dpiAff                 = getDpiAffine(sl, frameId);
+  player.m_ancestorColumnIndex    = -1;
+  player.m_opacity                = scene->getOverlayOpacity();
+
+  if (is3DView()) {
+    Stage::OpenGlPainter painter(viewAff, clipRect, m_visualSettings, true,
+                                 false);
+    painter.enableCamera3D(true);
+    painter.setPhi(m_phi3D);
+    if (ri)
+      painter.onRasterImage(ri.getPointer(), player);
+    else if (ti)
+      painter.onToonzImage(ti.getPointer(), player);
+    else
+      painter.onVectorImage(vi.getPointer(), player);
+  } else {
+    Stage::RasterPainter painter(TDimension(width(), height()), viewAff,
+                                 clipRect, m_visualSettings, true);
+    if (ri)
+      painter.onRasterImage(ri.getPointer(), player);
+    else if (ti)
+      painter.onToonzImage(ti.getPointer(), player);
+    else
+      painter.onVectorImage(vi.getPointer(), player);
+    painter.flushRasterImages();
   }
 }
 

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -328,6 +328,7 @@ protected:
   void drawViewerIndicators();
 
   void drawScene();
+  void drawSceneOverlay();
   void drawToolGadgets();
 
 protected:

--- a/toonz/sources/toonzlib/scenefx.cpp
+++ b/toonz/sources/toonzlib/scenefx.cpp
@@ -899,6 +899,10 @@ PlacedFx FxBuilder::makePF(TLevelColumnFx *lcfx) {
   bool columnVisible =
       getColumnPlacement(pf, m_xsh, m_frame, pf.m_columnIndex, m_isPreview);
 
+  const bool isOverlay =
+      !cell.isEmpty() && cell.getSimpleLevel() &&
+      cell.getSimpleLevel()->getName() == L"__Scene Overlay__";
+
   // if the cell is empty, only inherits its placement
   if ((m_particleDescendentCount == 0 && cell.isEmpty())) return pf;
 
@@ -925,7 +929,7 @@ PlacedFx FxBuilder::makePF(TLevelColumnFx *lcfx) {
     addPlasticDeformerFx(pf);
   }
 
-  if (columnVisible) {
+  if (columnVisible || isOverlay) {
     // Column is visible, alright
     TXshSimpleLevel *sl = cell.isEmpty() ? 0 : cell.m_level->getSimpleLevel();
     if (sl) {
@@ -971,7 +975,8 @@ PlacedFx FxBuilder::makePF(TLevelColumnFx *lcfx) {
 
     // Apply column's color filter and semi-transparency for rendering
     TXshLevelColumn *column = lcfx->getColumn();
-    if (m_scene->getProperties()->isColumnColorFilterOnRenderEnabled() &&
+    if ((m_scene->getProperties()->isColumnColorFilterOnRenderEnabled() ||
+         isOverlay) &&
         (column->getColorFilterId() != 0 ||  // None
          (column->isCamstandVisible() && column->getOpacity() != 255))) {
       TPixel32 colorScale = m_scene->getProperties()->getColorFilterColor(
@@ -1342,6 +1347,12 @@ TFxP buildSceneFx(ToonzScene *scene, TXsheet *xsh, double row, int whichLevels,
 
   fx = TFxUtil::makeOver(
       TFxUtil::makeColorCard(scene->getProperties()->getBgColor()), fx);
+
+  TLevelColumnFx *overlayFx = scene->getOverlayFx(row);
+  if (overlayFx) {
+    PlacedFx overlayPf = builder.makePF(overlayFx);
+    fx = TFxUtil::makeOver(fx, TFxUtil::makeAffine(overlayPf.makeFx(), aff));
+  }
   return fx;
 }
 
@@ -1490,6 +1501,12 @@ DVAPI TFxP buildPostSceneFx(ToonzScene *scene, double frame, int shrink,
   }
 
   if (!aff.isIdentity()) fx = TFxUtil::makeAffine(fx, aff);
+
+  TLevelColumnFx *overlayFx = scene->getOverlayFx(frame);
+  if (overlayFx) {
+    PlacedFx overlayPf = builder.makePF(overlayFx);
+    fx = TFxUtil::makeOver(fx, TFxUtil::makeAffine(overlayPf.makeFx(), aff));
+  }
 
   return fx;
 }

--- a/toonz/sources/toonzlib/sceneproperties.cpp
+++ b/toonz/sources/toonzlib/sceneproperties.cpp
@@ -74,7 +74,9 @@ TSceneProperties::TSceneProperties()
     , m_fieldGuideSize(16)
     , m_fieldGuideAspectRatio(1.77778)
     , m_columnColorFilterOnRender(false)
-    , m_camCapSaveInPath() {
+    , m_camCapSaveInPath()
+    , m_overlayFile()
+    , m_overlayOpacity(255) {
   // Default color
   m_notesColor.push_back(TPixel32(255, 235, 140));
   m_notesColor.push_back(TPixel32(255, 160, 120));
@@ -131,6 +133,8 @@ void TSceneProperties::assign(const TSceneProperties *sprop) {
   m_fieldGuideSize            = sprop->m_fieldGuideSize;
   m_fieldGuideAspectRatio     = sprop->m_fieldGuideAspectRatio;
   m_columnColorFilterOnRender = sprop->m_columnColorFilterOnRender;
+  m_overlayFile               = sprop->m_overlayFile;
+  m_overlayOpacity            = sprop->m_overlayOpacity;
   int i;
   for (i = 0; i < m_notesColor.size(); i++)
     m_notesColor.replace(i, sprop->getNoteColor(i));
@@ -394,6 +398,8 @@ void TSceneProperties::saveData(TOStream &os) const {
   if (m_columnColorFilterOnRender) os.child("columnColorFilterOnRender") << 1;
   if (!m_camCapSaveInPath.isEmpty())
     os.child("cameraCaputureSaveInPath") << m_camCapSaveInPath;
+  if (!m_overlayFile.isEmpty())
+    os.child("overlayFile") << m_overlayFile << m_overlayOpacity;
 
   os.openChild("noteColors");
   for (i = 0; i < m_notesColor.size(); i++) os << m_notesColor.at(i);
@@ -827,6 +833,8 @@ void TSceneProperties::loadData(TIStream &is, bool isLoadingProject) {
       assert(i == 7);
     } else if (tagName == "cameraCaputureSaveInPath") {
       is >> m_camCapSaveInPath;
+    } else if (tagName == "overlayFile") {
+      is >> m_overlayFile >> m_overlayOpacity;
     } else if (tagName == "cellMarks") {
       int i = 0;
       while (!is.eos()) {

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -29,6 +29,7 @@
 #include "toonz/txshpalettecolumn.h"
 #include "toonz/txshpalettelevel.h"
 #include "toonz/toonzfolders.h"
+#include "toonz/tcolumnfx.h"
 
 // TnzCore includes
 #include "timagecache.h"
@@ -277,7 +278,14 @@ static void deleteAllUntitledScenes() {
 // ToonzScene
 
 ToonzScene::ToonzScene()
-    : m_contentHistory(0), m_isUntitled(true), m_isLoading(false) {
+    : m_contentHistory(0)
+    , m_isUntitled(true)
+    , m_isLoading(false)
+    , m_overlayLoaded(false)
+    , m_overlayLevel(nullptr)
+    , m_overlayOpacity(255)
+    , m_overlayLevelColumn(nullptr)
+    , m_overlayFx(nullptr) {
   m_childStack = new ChildStack(this);
   m_properties = new TSceneProperties();
   m_levelSet   = new TLevelSet();
@@ -1623,4 +1631,66 @@ std::wstring ToonzScene::getLevelNameWithoutSceneNumber(std::wstring orgName) {
 
   return orgNameQstr.right(orgNameQstr.size() - orgNameQstr.indexOf("_") - 1)
       .toStdWString();
+}
+
+//-----------------------------------------------------------------------------
+
+void ToonzScene::loadOverlayFile(const TFilePath &overlayFile) {
+  const TFilePath decodedPath = decodeFilePath(overlayFile);
+
+  if (m_overlayLevel) {
+    if (decodedPath == decodeFilePath(m_overlayLevel->getPath())) return;
+
+    m_overlayFx->release();
+    m_overlayFx = nullptr;
+    m_overlayLevelColumn->release();
+    m_overlayLevelColumn = nullptr;
+    m_overlayLevel->release();
+    m_overlayLevel = nullptr;
+  }
+
+  m_overlayLoaded = false;
+  if (decodedPath.isEmpty() || !TFileStatus(decodedPath).doesExist()) return;
+
+  m_overlayLevel = loadLevel(decodedPath, 0, L"__Scene Overlay__");
+  if (!m_overlayLevel) return;
+
+  m_levelSet->removeLevel(m_overlayLevel, false);
+
+  m_overlayLevelColumn = new TXshLevelColumn;
+  m_overlayLevelColumn->addRef();
+  m_overlayLevelColumn->setCamstandVisible(true);
+  m_overlayLevelColumn->setOpacity(m_overlayOpacity);
+  m_overlayLevelColumn->setCell(
+      0, TXshCell(m_overlayLevel, m_overlayLevel->getSimpleLevel()->getFirstFid()));
+
+  m_overlayFx = new TLevelColumnFx;
+  m_overlayFx->addRef();
+  m_overlayFx->setColumn(m_overlayLevelColumn);
+  m_overlayLoaded = true;
+}
+
+//-----------------------------------------------------------------------------
+
+TXshLevel *ToonzScene::getOverlayLevel() {
+  if (!m_overlayLoaded) loadOverlayFile(m_properties->getOverlayFile());
+  return m_overlayLevel;
+}
+
+//-----------------------------------------------------------------------------
+
+void ToonzScene::setOverlayOpacity(int opacity) {
+  m_overlayOpacity = opacity;
+  if (m_overlayLevelColumn) m_overlayLevelColumn->setOpacity(opacity);
+}
+
+//-----------------------------------------------------------------------------
+
+TLevelColumnFx *ToonzScene::getOverlayFx(int row) {
+  if (!m_overlayLoaded) loadOverlayFile(m_properties->getOverlayFile());
+
+  if (m_overlayFx && m_overlayLevelColumn->getCell(row).isEmpty()) {
+    m_overlayLevelColumn->setCell(row, m_overlayLevelColumn->getCell(0));
+  }
+  return m_overlayFx;
 }

--- a/toonz/sources/toonzqt/camerasettingswidget.cpp
+++ b/toonz/sources/toonzqt/camerasettingswidget.cpp
@@ -171,7 +171,10 @@ void SimpleExpField::focusOutEvent(QFocusEvent *event) {
 //=============================================================================
 
 CameraSettingsWidget::CameraSettingsWidget(bool forCleanup)
-    : m_forCleanup(forCleanup), m_arValue(0), m_currentLevel(nullptr) {
+    : m_forCleanup(forCleanup)
+    , m_arValue(0)
+    , m_currentLevel(nullptr)
+    , m_overlayLevel(nullptr) {
   if (unitTrMap.isEmpty()) {
     unitTrMap["cm"]    = tr("cm");
     unitTrMap["mm"]    = tr("mm");
@@ -208,6 +211,7 @@ CameraSettingsWidget::CameraSettingsWidget(bool forCleanup)
   m_fspChk = new QPushButton("");
 
   m_useLevelSettingsBtn = new QPushButton(tr("Use Current Level Settings"));
+  m_useOverlaySettingsBtn = new QPushButton(tr("Use Scene Overlay Settings"));
 
   m_presetListOm    = new QComboBox();
   m_addPresetBtn    = new QPushButton(tr("Add"));
@@ -216,6 +220,8 @@ CameraSettingsWidget::CameraSettingsWidget(bool forCleanup)
   //----
   m_useLevelSettingsBtn->setEnabled(false);
   m_useLevelSettingsBtn->setFocusPolicy(Qt::NoFocus);
+  m_useOverlaySettingsBtn->setEnabled(false);
+  m_useOverlaySettingsBtn->setFocusPolicy(Qt::NoFocus);
   m_lxFld->installEventFilter(this);
   m_lyFld->installEventFilter(this);
   m_arFld->installEventFilter(this);
@@ -321,6 +327,7 @@ CameraSettingsWidget::CameraSettingsWidget(bool forCleanup)
     mainLay->addLayout(gridLay);
 
     mainLay->addWidget(m_useLevelSettingsBtn);
+    mainLay->addWidget(m_useOverlaySettingsBtn);
 
     QHBoxLayout *resListLay = new QHBoxLayout();
     resListLay->setSpacing(3);
@@ -368,6 +375,8 @@ CameraSettingsWidget::CameraSettingsWidget(bool forCleanup)
 
   connect(m_useLevelSettingsBtn, &QPushButton::clicked, this,
           &CameraSettingsWidget::useLevelSettings);
+  connect(m_useOverlaySettingsBtn, &QPushButton::clicked, this,
+          &CameraSettingsWidget::useOverlaySettings);
 
   // Using textActivated instead of activated (deprecated in Qt 5.15)
   connect(m_presetListOm, &QComboBox::textActivated, this,
@@ -379,7 +388,10 @@ CameraSettingsWidget::CameraSettingsWidget(bool forCleanup)
           &CameraSettingsWidget::removePreset);
 }
 
-CameraSettingsWidget::~CameraSettingsWidget() { setCurrentLevel(nullptr); }
+CameraSettingsWidget::~CameraSettingsWidget() {
+  setCurrentLevel(nullptr);
+  setOverlayLevel(nullptr);
+}
 
 void CameraSettingsWidget::showEvent(QShowEvent *e) {
   if (Preferences::instance()->getCameraUnits() == "pixel") {
@@ -567,8 +579,27 @@ void CameraSettingsWidget::setCurrentLevel(TXshLevel *xshLevel) {
 }
 
 void CameraSettingsWidget::useLevelSettings() {
-  TXshSimpleLevel *sl = m_currentLevel;
-  if (!sl) return;
+  if (applyLevelSettings(m_currentLevel)) {
+    emit levelSettingsUsed();
+    emit changed();
+  }
+}
+
+void CameraSettingsWidget::setOverlayLevel(TXshLevel *xshLevel) {
+  TXshSimpleLevel *level = xshLevel ? xshLevel->getSimpleLevel() : nullptr;
+  if (level == m_overlayLevel) return;
+  if (m_overlayLevel) m_overlayLevel->release();
+  m_overlayLevel = level;
+  if (m_overlayLevel) m_overlayLevel->addRef();
+  m_useOverlaySettingsBtn->setEnabled(m_overlayLevel != nullptr);
+}
+
+void CameraSettingsWidget::useOverlaySettings() {
+  if (applyLevelSettings(m_overlayLevel)) emit changed();
+}
+
+bool CameraSettingsWidget::applyLevelSettings(TXshSimpleLevel *sl) {
+  if (!sl) return false;
 
   // Build dpi
   TPointD dpi = sl->getDpi(TFrameId::NO_FRAME, 0);
@@ -576,7 +607,7 @@ void CameraSettingsWidget::useLevelSettings() {
   // Build physical size
   TDimensionD size(0, 0);
   TDimension res = sl->getResolution();
-  if (res.lx <= 0 || res.ly <= 0 || dpi.x <= 0 || dpi.y <= 0) return;
+  if (res.lx <= 0 || res.ly <= 0 || dpi.x <= 0 || dpi.y <= 0) return false;
 
   size.lx = res.lx / dpi.x;
   size.ly = res.ly / dpi.y;
@@ -586,8 +617,7 @@ void CameraSettingsWidget::useLevelSettings() {
   camera.setSize(size);
   camera.setRes(res);
   setFields(&camera);
-  emit levelSettingsUsed();
-  emit changed();
+  return true;
 }
 
 void CameraSettingsWidget::setFields(const TCamera *camera) {


### PR DESCRIPTION
Adds a scene-owned overlay image with persisted path and opacity settings.

Displays the overlay in the camera stand, matches camera settings from the overlay image, and composites it in normal and multiple render-tree entry points.