### PR TITLE
[T2D-106] Add drawing marks

### DIFF
--- a/toonz/sources/include/toonz/txshsimplelevel.h
+++ b/toonz/sources/include/toonz/txshsimplelevel.h
@@ -287,6 +287,12 @@ public:
   //! must have the same size).
   void renumber(const std::vector<TFrameId> &fids);
 
+  const std::map<TFrameId, int> &getDrawingMarks() const {
+    return m_drawingMarks;
+  }
+  int getDrawingMark(const TFrameId &fid) const;
+  void setDrawingMark(const TFrameId &fid, int markId);
+
   bool isFrameReadOnly(TFrameId fid);
 
 public:
@@ -373,6 +379,7 @@ private:
   bool m_isReadOnly;
   bool m_temporaryHookMerged;  //!< Used only during hook merge (and hence
                                //!< during saving)
+  std::map<TFrameId, int> m_drawingMarks;
 
 private:
   //! Save simple level in scene-decoded path \p decodedFp.

--- a/toonz/sources/include/toonzqt/menubarcommand.h
+++ b/toonz/sources/include/toonzqt/menubarcommand.h
@@ -67,6 +67,7 @@ enum CommandType {
   ZoomCommandType,
   MiscCommandType,
   StopMotionCommandType,
+  DrawingMarkCommandType,
   CellMarkCommandType,
   MenuCommandType,
   VisualizationButtonCommandType,

--- a/toonz/sources/toonz/commandbarpopup.cpp
+++ b/toonz/sources/toonz/commandbarpopup.cpp
@@ -131,6 +131,8 @@ CommandListTree::CommandListTree(const QString& dropTargetString,
   QTreeWidgetItem* rcmSubFolder =
       addFolder(ShortcutTree::tr("Right-click Menu Commands"),
                 RightClickMenuCommandType, advancedFolder);
+  addFolder(ShortcutTree::tr("Drawing Mark"), DrawingMarkCommandType,
+            rcmSubFolder);
   addFolder(ShortcutTree::tr("Cell Mark"), CellMarkCommandType, rcmSubFolder);
   QTreeWidgetItem* toolModifiersFolder =
       addFolder(ShortcutTree::tr("Tool Modifiers"), ToolModifierCommandType,
@@ -213,6 +215,8 @@ void CommandListTree::refreshTree() {
   QTreeWidgetItem* rcmSubFolder =
       addFolder(ShortcutTree::tr("Right-click Menu Commands"),
                 RightClickMenuCommandType, advancedFolder);
+  addFolder(ShortcutTree::tr("Drawing Mark"), DrawingMarkCommandType,
+            rcmSubFolder);
   addFolder(ShortcutTree::tr("Cell Mark"), CellMarkCommandType, rcmSubFolder);
   QTreeWidgetItem* toolModifiersFolder =
       addFolder(ShortcutTree::tr("Tool Modifiers"), ToolModifierCommandType,

--- a/toonz/sources/toonz/drawingdata.cpp
+++ b/toonz/sources/toonz/drawingdata.cpp
@@ -162,11 +162,13 @@ DrawingData *DrawingData::clone() const { return new DrawingData(this); }
 //-----------------------------------------------------------------------------
 
 void DrawingData::setLevelFrames(TXshSimpleLevel *sl,
-                                 std::set<TFrameId> &frames) {
+                                 std::set<TFrameId> &frames,
+                                 bool copyDrawingMarks) {
   if (!sl || frames.empty()) return;
 
   m_level = sl;
   m_imageSet.clear();
+  m_drawingMarks.clear();
 
   std::set<TFrameId>::iterator it;
 
@@ -202,6 +204,9 @@ void DrawingData::setLevelFrames(TXshSimpleLevel *sl,
       copiedHook->setAPos(frameId, levelHook->getAPos(frameId));
       copiedHook->setBPos(frameId, levelHook->getBPos(frameId));
     }
+
+    if (copyDrawingMarks)
+      m_drawingMarks[frameId] = sl->getDrawingMark(frameId);
   }
 }
 
@@ -338,6 +343,16 @@ bool DrawingData::getLevelFrames(TXshSimpleLevel *sl,
     ++frameIt;
   }
 
+  if (!m_drawingMarks.empty()) {
+    frameIt = m_imageSet.begin();
+    for (auto const &image : usedImageSet) {
+      const auto markIt = m_drawingMarks.find(frameIt->first);
+      sl->setDrawingMark(image.first,
+                         markIt == m_drawingMarks.end() ? -1 : markIt->second);
+      ++frameIt;
+    }
+  }
+
   sl->setDirtyFlag(true);
 
   // notify if there are any modifications to the palette
@@ -423,8 +438,10 @@ TImageP DrawingData::getImage(QString imageId, TXshSimpleLevel *sl,
 //-----------------------------------------------------------------------------
 
 void DrawingData::setFrames(const std::map<TFrameId, QString> &imageSet,
-                            TXshSimpleLevel *level, const HookSet &levelHooks) {
-  m_levelHooks = levelHooks;
+                            TXshSimpleLevel *level, const HookSet &levelHooks,
+                            const std::map<TFrameId, int> &drawingMarks) {
+  m_levelHooks   = levelHooks;
+  m_drawingMarks = drawingMarks;
   m_imageSet.clear();
 
   assert(!imageSet.empty());

--- a/toonz/sources/toonz/drawingdata.h
+++ b/toonz/sources/toonz/drawingdata.h
@@ -23,6 +23,7 @@ public:
   HookSet m_levelHooks;
   TXshSimpleLevelP m_level;
   bool m_keepVectorFills = false;
+  std::map<TFrameId, int> m_drawingMarks;
 
   /*! Define possible level image setting.
   *  \li INSERT Insert images before first selected;
@@ -36,7 +37,8 @@ public:
   DrawingData(const DrawingData *src)
       : m_imageSet(src->m_imageSet)
       , m_level(src->m_level)
-      , m_levelHooks(src->m_levelHooks) {}
+      , m_levelHooks(src->m_levelHooks)
+      , m_drawingMarks(src->m_drawingMarks) {}
 
   void releaseData() override;
   ~DrawingData();
@@ -44,7 +46,8 @@ public:
   DrawingData *clone() const override;
 
   // data <- filmstrip
-  void setLevelFrames(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
+  void setLevelFrames(TXshSimpleLevel *sl, std::set<TFrameId> &frames,
+                      bool copyDrawingMarks = false);
 
   // data -> filmstrip
   // Se setType == INSERT inserisce i frames nel livello se necessario spostando
@@ -55,7 +58,8 @@ public:
 
   // Image must be put in cache before call this.
   void setFrames(const std::map<TFrameId, QString> &imageSet,
-                 TXshSimpleLevel *level, const HookSet &levelHooks);
+                 TXshSimpleLevel *level, const HookSet &levelHooks,
+                 const std::map<TFrameId, int> &drawingMarks);
   // Return frameId contained in m_imageSet.
   void getFrames(std::set<TFrameId> &frameId) const;
   TXshSimpleLevel *getLevel() const { return m_level.getPointer(); }

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -11,6 +11,7 @@
 #include "filmstripselection.h"
 #include "onionskinmaskgui.h"
 #include "comboviewerpane.h"
+#include "xshcellviewer.h"
 
 // TnzQt includes
 #include "toonzqt/icongenerator.h"
@@ -35,6 +36,7 @@
 #include "toonz/toonzscene.h"
 #include "toonz/levelset.h"
 #include "toonz/preferences.h"
+#include "toonz/sceneproperties.h"
 
 // TnzCore includes
 #include "tpalette.h"
@@ -51,6 +53,12 @@
 #include <QDrag>
 
 namespace {
+QIcon getColorChipIcon(const TPixel32 &color) {
+  QPixmap pixmap(15, 15);
+  pixmap.fill(QColor(color.r, color.g, color.b));
+  return QIcon(pixmap);
+}
+
 QString fidToFrameNumberWithLetter(int f) {
   QString str = QString::number((int)(f / 10));
   while (str.length() < 3) str.push_front("0");
@@ -776,6 +784,25 @@ void FilmstripFrames::drawFrameIcon(QPainter &p, const QRect &r, int index,
   if (!pm.isNull()) {
     p.drawPixmap(r.left(), r.top(), pm);
 
+    const int markId = sl->getDrawingMark(fid);
+    if (markId >= 0) {
+      const TPixel32 color = TApp::instance()
+                                 ->getCurrentScene()
+                                 ->getScene()
+                                 ->getProperties()
+                                 ->getCellMark(markId)
+                                 .color;
+      const int markerSize = 20;
+      p.save();
+      p.setPen(QColor(color.r + 50, color.g + 50, color.b + 50));
+      p.setBrush(QColor(color.r, color.g, color.b));
+      const QPoint points[3] = {QPoint(r.left(), r.top()),
+                                QPoint(r.left() + markerSize, r.top()),
+                                QPoint(r.left(), r.top() + markerSize)};
+      p.drawPolygon(points, 3);
+      p.restore();
+    }
+
     if (sl && sl->getType() == PLI_XSHLEVEL && flags & F_INBETWEEN_RANGE) {
       if (m_isVertical) {
         int x1 = r.right();
@@ -1285,6 +1312,34 @@ void FilmstripFrames::contextMenuEvent(QContextMenuEvent *event) {
              (sl->getType() == OVL_XSHLEVEL && !sl->getPath().isUneditable())))
     menu->addAction(cm->getAction(MI_RevertToLastSaved));
   menu->addSeparator();
+
+  if (sl && !m_selection->isEmpty()) {
+    QMenu *marksMenu = menu->addMenu(tr("Drawing Mark"));
+    const auto selected = m_selection->getSelectedFids();
+    const TFrameId firstFid = *selected.begin();
+    const int currentMark = selected.size() == 1
+                                ? sl->getDrawingMark(firstFid)
+                                : -2;
+    QAction *action = marksMenu->addAction(tr("None"));
+    action->setCheckable(true);
+    action->setChecked(currentMark == -1);
+    action->setData(-1);
+    connect(action, &QAction::triggered, this,
+            &FilmstripFrames::onSetDrawingMark);
+    const auto marks = TApp::instance()->getCurrentScene()->getScene()
+                           ->getProperties()
+                           ->getCellMarks();
+    for (int id = 0; id < marks.size(); ++id) {
+      action = marksMenu->addAction(getColorChipIcon(marks[id].color),
+                                    QString("%1: %2").arg(id).arg(marks[id].name));
+      action->setCheckable(true);
+      action->setChecked(currentMark == id);
+      action->setData(id);
+      connect(action, &QAction::triggered, this,
+              &FilmstripFrames::onSetDrawingMark);
+    }
+    menu->addSeparator();
+  }
   createSelectLevelMenu(menu);
   QMenu *panelMenu           = menu->addMenu(tr("Panel Settings"));
   QAction *toggleOrientation = panelMenu->addAction(tr("Toggle Orientation"));
@@ -1303,6 +1358,17 @@ void FilmstripFrames::contextMenuEvent(QContextMenuEvent *event) {
           SLOT(navigatorToggled(bool)));
 
   menu->exec(event->globalPos());
+}
+
+//-----------------------------------------------------------------------------
+
+void FilmstripFrames::onSetDrawingMark() {
+  QAction *action = qobject_cast<QAction *>(sender());
+  TXshSimpleLevel *level = getLevel();
+  if (!action || !level || m_selection->isEmpty()) return;
+
+  std::set<TFrameId> frames = m_selection->getSelectedFids();
+  FilmstripCmd::setDrawingMark(level, frames, action->data().toInt());
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/filmstrip.h
+++ b/toonz/sources/toonz/filmstrip.h
@@ -172,6 +172,7 @@ protected slots:
   void navigatorToggled(bool);
   void levelSelected(int);
   void onViewerAboutToBeDestroyed();
+  void onSetDrawingMark();
 
 private:
   // QSS Properties

--- a/toonz/sources/toonz/filmstripcommand.cpp
+++ b/toonz/sources/toonz/filmstripcommand.cpp
@@ -165,7 +165,7 @@ namespace {
 void copyFramesWithoutUndo(TXshSimpleLevel *sl, std::set<TFrameId> &frames) {
   QClipboard *clipboard = QApplication::clipboard();
   auto *data            = new DrawingData();
-  data->setLevelFrames(sl, frames);
+  data->setLevelFrames(sl, frames, true);
   clipboard->setMimeData(data, QClipboard::Clipboard);
 }
 
@@ -423,6 +423,7 @@ void cutFramesWithoutUndo(TXshSimpleLevel *sl, std::set<TFrameId> &frames) {
   std::map<TFrameId, QString> imageSet;
 
   HookSet *levelHooks   = sl->getHookSet();
+  const std::map<TFrameId, int> drawingMarks = sl->getDrawingMarks();
   int currentFrameIndex = TApp::instance()->getCurrentFrame()->getFrameIndex();
   int i                 = 0;
   for (const TFrameId &frameId : frames) {
@@ -436,7 +437,7 @@ void cutFramesWithoutUndo(TXshSimpleLevel *sl, std::set<TFrameId> &frames) {
 
   QClipboard *clipboard = QApplication::clipboard();
   auto *data            = new DrawingData();
-  data->setFrames(imageSet, sl, *levelHooks);
+  data->setFrames(imageSet, sl, *levelHooks, drawingMarks);
   clipboard->setMimeData(data, QClipboard::Clipboard);
 
   for (const TFrameId &fid : frames) sl->eraseFrame(fid);
@@ -1511,7 +1512,7 @@ void FilmstripCmd::merge(TXshSimpleLevel *sl, std::set<TFrameId> &frames) {
           dynamic_cast<const DrawingData *>(clipboard->mimeData())) {
     drawingData->getFrames(frameIdToChange);
     auto *data = new DrawingData();
-    data->setLevelFrames(sl, frameIdToChange);
+    data->setLevelFrames(sl, frameIdToChange, true);
     auto *oldLevelHooks = new HookSet();
     *oldLevelHooks      = *sl->getHookSet();
 
@@ -1548,7 +1549,7 @@ void FilmstripCmd::pasteInto(TXshSimpleLevel *sl, std::set<TFrameId> &frames) {
   if (const auto *drawingData =
           dynamic_cast<const DrawingData *>(clipboard->mimeData())) {
     auto *data = new DrawingData();
-    data->setLevelFrames(sl, frames);
+    data->setLevelFrames(sl, frames, true);
 
     auto *oldLevelHooks = new HookSet();
     *oldLevelHooks      = *sl->getHookSet();
@@ -1598,12 +1599,13 @@ void FilmstripCmd::clear(TXshSimpleLevel *sl, std::set<TFrameId> &frames) {
     }
   }
 
-  HookSet *levelHooks          = sl->getHookSet();
+  HookSet *levelHooks                  = sl->getHookSet();
+  const std::map<TFrameId, int> drawingMarks = sl->getDrawingMarks();
   std::set<TFrameId> oldFrames = frames;
   std::map<TFrameId, QString> clearedFrames =
       clearFramesWithoutUndo(sl, frames);
   auto *oldData = new DrawingData();
-  oldData->setFrames(clearedFrames, sl, *levelHooks);
+  oldData->setFrames(clearedFrames, sl, *levelHooks, drawingMarks);
   auto *newData = new DrawingData();
   newData->setLevelFrames(sl, frames);
   frames.clear();
@@ -1627,8 +1629,9 @@ void FilmstripCmd::remove(TXshSimpleLevel *sl, std::set<TFrameId> &frames) {
     imageSet[frameId] = id;
   }
   HookSet *levelHooks = sl->getHookSet();
+  const std::map<TFrameId, int> drawingMarks = sl->getDrawingMarks();
   auto *oldData       = new DrawingData();
-  oldData->setFrames(imageSet, sl, *levelHooks);
+  oldData->setFrames(imageSet, sl, *levelHooks, drawingMarks);
 
   removeFramesWithoutUndo(sl, frames);
   TUndoManager::manager()->add(new RemoveFramesUndo(sl, frames, oldData));
@@ -2501,4 +2504,52 @@ void FilmstripCmd::renumberDrawing(TXshSimpleLevel *sl, const TFrameId &oldFid,
   TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
   TApp::instance()->getCurrentLevel()->notifyLevelChange();
   TApp::instance()->getCurrentScene()->setDirtyFlag(true);
+}
+
+//-----------------------------------------------------------------------------
+
+namespace {
+
+class SetDrawingMarkUndo final : public TUndo {
+  TXshSimpleLevelP m_level;
+  std::map<TFrameId, int> m_oldMarks;
+  int m_newMark;
+
+public:
+  SetDrawingMarkUndo(TXshSimpleLevel *level, const std::set<TFrameId> &frames,
+                     int markId)
+      : m_level(level), m_newMark(markId) {
+    for (const TFrameId &frame : frames)
+      m_oldMarks[frame] = level->getDrawingMark(frame);
+  }
+
+  void undo() const override {
+    for (const auto &entry : m_oldMarks)
+      m_level->setDrawingMark(entry.first, entry.second);
+    TApp::instance()->getCurrentLevel()->notifyLevelChange();
+    TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+  }
+
+  void redo() const override {
+    for (const auto &entry : m_oldMarks)
+      m_level->setDrawingMark(entry.first, m_newMark);
+    TApp::instance()->getCurrentLevel()->notifyLevelChange();
+    TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+  }
+
+  int getSize() const override { return sizeof(*this); }
+  QString getHistoryString() override {
+    return QObject::tr("Set Drawing Mark to %1").arg(m_newMark);
+  }
+  int getHistoryType() override { return HistoryType::FilmStrip; }
+};
+
+}  // namespace
+
+void FilmstripCmd::setDrawingMark(TXshSimpleLevel *sl,
+                                  std::set<TFrameId> &frames, int markId) {
+  if (!sl || sl->isSubsequence() || frames.empty()) return;
+  auto *undo = new SetDrawingMarkUndo(sl, frames, markId);
+  undo->redo();
+  TUndoManager::manager()->add(undo);
 }

--- a/toonz/sources/toonz/filmstripcommand.h
+++ b/toonz/sources/toonz/filmstripcommand.h
@@ -71,6 +71,8 @@ void inbetween(TXshSimpleLevel *sl, const TFrameId &fid0, const TFrameId &fid1,
 // Renumber a single drawing
 void renumberDrawing(TXshSimpleLevel *sl, const TFrameId &oldFid,
                      const TFrameId &desiredNewFid);
+void setDrawingMark(TXshSimpleLevel *sl, std::set<TFrameId> &frames,
+                    int markId);
 
 }  // namespace FilmstripCmd
 

--- a/toonz/sources/toonz/filmstripselection.cpp
+++ b/toonz/sources/toonz/filmstripselection.cpp
@@ -369,6 +369,14 @@ void TFilmstripSelection::eachFrames(int each) {
 
 //-----------------------------------------------------------------------------
 
+void TFilmstripSelection::setDrawingMark(int markId) {
+  if (markId < -1) return;
+  TXshSimpleLevel *level = TApp::instance()->getCurrentLevel()->getSimpleLevel();
+  if (level) FilmstripCmd::setDrawingMark(level, m_selectedFrames, markId);
+}
+
+//-----------------------------------------------------------------------------
+
 void TFilmstripSelection::duplicateFrames() {
   TXshSimpleLevel *sl = TApp::instance()->getCurrentLevel()->getSimpleLevel();
   if (sl) FilmstripCmd::duplicate(sl, m_selectedFrames, true);

--- a/toonz/sources/toonz/filmstripselection.h
+++ b/toonz/sources/toonz/filmstripselection.h
@@ -56,6 +56,7 @@ public:
   void swingFrames();
   void stepFrames(int step);
   void eachFrames(int step);
+  void setDrawingMark(int markId);
   void duplicateFrames();
   void exposeFrames();
   void renumberFrames();

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -3374,6 +3374,16 @@ void MainWindow::defineActions() {
   // Special Modifier Keys
   createSpecialModifierAction(V_Scrub, QT_TR_NOOP("Viewer Scrub"), "#");
 
+  for (int markId = 0; markId < 12; ++markId) {
+    const std::string commandId =
+        (std::string)MI_SetDrawingMark + std::to_string(markId);
+    const std::string label =
+        QT_TR_NOOP("Set Drawing Mark ") + std::to_string(markId);
+    QAction *action = createAction(commandId.c_str(), label.c_str(), "",
+                                   DrawingMarkCommandType);
+    action->setData(markId);
+  }
+
   // create cell mark actions
   for (int markId = 0; markId < 12; markId++) {
     std::string cmdId = (std::string)MI_SetCellMark + std::to_string(markId);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -496,6 +496,9 @@
 #define MI_ExportXsheetPDF "MI_ExportXsheetPDF"
 #define MI_ExportCameraTrack "MI_ExportCameraTrack"
 
+// mark id is added for each actual command (i.g. MI_SetDrawingMark1)
+#define MI_SetDrawingMark "MI_SetDrawingMark"
+
 // mark id is added for each actual command (i.g. MI_SetCellMark1)
 #define MI_SetCellMark "MI_SetCellMark"
 

--- a/toonz/sources/toonz/scenesettingspopup.cpp
+++ b/toonz/sources/toonz/scenesettingspopup.cpp
@@ -81,7 +81,7 @@ public:
   int getSize() const override { return sizeof *this; }
 
   QString getHistoryString() override {
-    return QObject::tr("Edit Cell Mark #%1").arg(QString::number(m_id));
+    return QObject::tr("Edit Cell/Drawing Mark #%1").arg(QString::number(m_id));
   }
 };
 
@@ -164,7 +164,7 @@ QImage::Format_ARGB32);
 //-----------------------------------------------------------------------------
 
 CellMarksPopup::CellMarksPopup(QWidget *parent) : QDialog(parent) {
-  setWindowTitle(tr("Cell Marks Settings"));
+  setWindowTitle(tr("Marks Settings"));
 
   QList<TSceneProperties::CellMark> marks = TApp::instance()
                                                 ->getCurrentScene()
@@ -502,7 +502,7 @@ SceneSettingsPopup::SceneSettingsPopup()
       sprop->isColumnColorFilterOnRenderEnabled());
 
   QPushButton *editCellMarksButton =
-      new QPushButton(tr("Edit Cell Marks"), this);
+      new QPushButton(tr("Edit Marks"), this);
 
   QPushButton *editColorFiltersButton =
       new QPushButton(tr("Edit Column Color Filters"), this);
@@ -553,7 +553,7 @@ SceneSettingsPopup::SceneSettingsPopup()
                           Qt::AlignRight | Qt::AlignVCenter);
 
     // cell marks
-    mainLayout->addWidget(new QLabel(tr("Cell Marks:"), this), 7, 0,
+    mainLayout->addWidget(new QLabel(tr("Cell/Drawing Marks:"), this), 7, 0,
                           Qt::AlignRight | Qt::AlignVCenter);
     mainLayout->addWidget(editCellMarksButton, 7, 1, 1, 4,
                           Qt::AlignLeft | Qt::AlignVCenter);

--- a/toonz/sources/toonz/shortcutpopup.cpp
+++ b/toonz/sources/toonz/shortcutpopup.cpp
@@ -296,6 +296,7 @@ ShortcutTree::ShortcutTree(QWidget *parent) : QTreeWidget(parent) {
 
   addFolder(tr("Right-click Menu Commands"), RightClickMenuCommandType);
   QTreeWidgetItem *rcmSubFolder = m_folders.back();
+  addFolder(tr("Drawing Mark"), DrawingMarkCommandType, rcmSubFolder);
   addFolder(tr("Cell Mark"), CellMarkCommandType, rcmSubFolder);
 
   addFolder(tr("Tools"), ToolCommandType);
@@ -453,6 +454,7 @@ void ShortcutTree::refreshTree() {
 
   addFolder(tr("Right-click Menu Commands"), RightClickMenuCommandType);
   QTreeWidgetItem *rcmSubFolder = m_folders.back();
+  addFolder(tr("Drawing Mark"), DrawingMarkCommandType, rcmSubFolder);
   addFolder(tr("Cell Mark"), CellMarkCommandType, rcmSubFolder);
 
   addFolder(tr("Tools"), ToolCommandType);

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -73,6 +73,8 @@
 #include <QClipboard>
 #include <QRegularExpression>
 
+#include <algorithm>
+
 namespace {
 
 const bool checkContainsSingleLevel(TXshColumn *column,
@@ -614,6 +616,46 @@ QString SetCellMarkUndo::getHistoryString() {
       .arg(markName);
 }
 int SetCellMarkUndo::getHistoryType() { return HistoryType::Xsheet; }
+
+//=============================================================================
+// SetDrawingMarkUndo
+//-----------------------------------------------------------------------------
+
+SetDrawingMarkUndo::SetDrawingMarkUndo(std::vector<TXshCell> cells, int markId)
+    : m_cells(std::move(cells)), m_newMark(markId) {
+  m_oldMarks.reserve(m_cells.size());
+  for (const TXshCell &cell : m_cells)
+    m_oldMarks.push_back(cell.getSimpleLevel()->getDrawingMark(cell.getFrameId()));
+}
+
+void SetDrawingMarkUndo::undo() const {
+  for (size_t i = 0; i < m_cells.size(); ++i)
+    m_cells[i].getSimpleLevel()->setDrawingMark(m_cells[i].getFrameId(),
+                                                m_oldMarks[i]);
+  TApp::instance()->getCurrentLevel()->notifyLevelChange();
+  TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+}
+
+void SetDrawingMarkUndo::redo() const {
+  for (const TXshCell &cell : m_cells)
+    cell.getSimpleLevel()->setDrawingMark(cell.getFrameId(), m_newMark);
+  TApp::instance()->getCurrentLevel()->notifyLevelChange();
+  TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
+}
+
+int SetDrawingMarkUndo::getSize() const { return sizeof(*this); }
+
+QString SetDrawingMarkUndo::getHistoryString() {
+  const QString markName =
+      m_newMark < 0
+          ? QObject::tr("None", "Drawing Mark")
+          : TApp::instance()->getCurrentScene()->getScene()->getProperties()
+                ->getCellMark(m_newMark)
+                .name;
+  return QObject::tr("Set Drawing Mark to %1").arg(markName);
+}
+
+int SetDrawingMarkUndo::getHistoryType() { return HistoryType::Xsheet; }
 
 //=============================================================================
 // RenameCellField
@@ -1871,6 +1913,35 @@ void CellArea::drawFrameMarker(QPainter &p, const QPoint &xy, QColor color,
 
 //-----------------------------------------------------------------------------
 
+void CellArea::drawDrawingMarker(QPainter &p, int markId, const QRect &rect) {
+  if (markId < 0) return;
+
+  const TPixel32 color = TApp::instance()
+                             ->getCurrentScene()
+                             ->getScene()
+                             ->getProperties()
+                             ->getCellMark(markId)
+                             .color;
+  const QColor markerColor(color.r, color.g, color.b);
+  const QColor borderColor(std::min(255, color.r + 50),
+                           std::min(255, color.g + 50),
+                           std::min(255, color.b + 50));
+  const int size = std::min(rect.width(), rect.height());
+  const QPoint topLeft = rect.topLeft();
+  const QPolygon marker({topLeft, QPoint(topLeft.x() + size, topLeft.y()),
+                         QPoint(topLeft.x(), topLeft.y() + rect.height())});
+
+  const QBrush oldBrush = p.brush();
+  const QPen oldPen     = p.pen();
+  p.setBrush(markerColor);
+  p.setPen(borderColor);
+  p.drawPolygon(marker);
+  p.setBrush(oldBrush);
+  p.setPen(oldPen);
+}
+
+//-----------------------------------------------------------------------------
+
 void CellArea::drawFocusCellBorder(QPainter &p) {
   QColor color = m_viewer->getCellFocusColor();
   if (color.alpha() == 0) return;
@@ -2078,6 +2149,19 @@ void CellArea::drawLevelCell(QPainter &p, int row, int col, bool isReference,
   drawLockedDottedLine(p, xsh->getColumn(col)->isLocked(), xy, cellColor);
 
   drawFrameSeparator(p, row, col, false, heldFrame);
+
+  const bool isStart = row == 0 || prevCell.isEmpty() ||
+                       prevCell.m_level.getPointer() != cell.m_level.getPointer() ||
+                       prevCell.m_frameId != cell.m_frameId;
+  if (isStart) {
+    if (TXshSimpleLevel *level = cell.getSimpleLevel()) {
+      QRect drawingMarkRect = rect.adjusted(1, 1, 1, 0);
+      if (!o->isVerticalTimeline())
+        drawingMarkRect.adjust(0, 0, nextCell.isEmpty() ? -2 : -4, 0);
+      drawDrawingMarker(p, level->getDrawingMark(cell.m_frameId),
+                        drawingMarkRect);
+    }
+  }
 
   QRect nameRect = o->rect(PredefinedRect::CELL_NAME).translated(QPoint(x, y));
 
@@ -4086,6 +4170,33 @@ void CellArea::createCellMenu(QMenu &menu, bool isCellSelected, TXshCell cell,
 
     menu.addMenu(marksMenu);
   }
+
+  TXshSimpleLevel *level = cell.getSimpleLevel();
+  if (level) {
+    QMenu *marksMenu = new QMenu(tr("Drawing Mark"), this);
+    const int markId = level->getDrawingMark(cell.getFrameId());
+    QAction *markAction = marksMenu->addAction(tr("None"));
+    markAction->setCheckable(true);
+    markAction->setChecked(markId == -1);
+    markAction->setEnabled(markId != -1);
+    markAction->setData(QList<QVariant>{row, col, -1});
+    connect(markAction, &QAction::triggered, this,
+            &CellArea::onSetDrawingMark);
+    const auto marks = TApp::instance()->getCurrentScene()->getScene()
+                           ->getProperties()
+                           ->getCellMarks();
+    for (int id = 0; id < marks.size(); ++id) {
+      markAction = marksMenu->addAction(getColorChipIcon(marks[id].color),
+                                        QString("%1: %2").arg(id).arg(marks[id].name));
+      markAction->setCheckable(true);
+      markAction->setChecked(markId == id);
+      markAction->setEnabled(markId != id);
+      markAction->setData(QList<QVariant>{row, col, id});
+      connect(markAction, &QAction::triggered, this,
+              &CellArea::onSetDrawingMark);
+    }
+    menu.addMenu(marksMenu);
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -4347,6 +4458,41 @@ void CellArea::onSetCellMark() {
   int col               = params[1].toInt();
   int id                = params[2].toInt();
   SetCellMarkUndo *undo = new SetCellMarkUndo(row, col, id);
+  undo->redo();
+  TUndoManager::manager()->add(undo);
+}
+
+//-----------------------------------------------------------------------------
+
+void CellArea::onSetDrawingMark() {
+  const QAction *action = qobject_cast<QAction *>(sender());
+  if (!action) return;
+  const QList<QVariant> params = action->data().toList();
+  if (params.size() != 3) return;
+
+  TCellSelection *selection = m_viewer->getCellSelection();
+  TXsheet *xsheet            = m_viewer->getXsheet();
+  std::vector<TXshCell> cells;
+  if (selection && !selection->isEmpty()) {
+    int r0, c0, r1, c1;
+    selection->getSelectedCells(r0, c0, r1, c1);
+    for (int col = std::max(0, c0); col <= c1; ++col) {
+      for (int row = r0; row <= r1; ++row) {
+        const TXshCell cell = xsheet->getCell(row, col);
+        if (cell.isEmpty() || !cell.getSimpleLevel() ||
+            std::find(cells.begin(), cells.end(), cell) != cells.end())
+          continue;
+        cells.push_back(cell);
+      }
+    }
+  }
+  if (cells.empty()) {
+    const TXshCell cell = xsheet->getCell(params[0].toInt(), params[1].toInt());
+    if (cell.isEmpty() || !cell.getSimpleLevel()) return;
+    cells.push_back(cell);
+  }
+
+  auto *undo = new SetDrawingMarkUndo(std::move(cells), params[2].toInt());
   undo->redo();
   TUndoManager::manager()->add(undo);
 }

--- a/toonz/sources/toonz/xshcellviewer.h
+++ b/toonz/sources/toonz/xshcellviewer.h
@@ -5,6 +5,7 @@
 
 #include <QWidget>
 #include <QLineEdit>
+#include <vector>
 #include "orientation.h"
 
 #include "toonz/txshcell.h"
@@ -25,6 +26,20 @@ class SetCellMarkUndo final : public TUndo {
 public:
   SetCellMarkUndo(int row, int col, int idAfter);
   void setId(int id) const;
+  void undo() const override;
+  void redo() const override;
+  int getSize() const override;
+  QString getHistoryString() override;
+  int getHistoryType() override;
+};
+
+class SetDrawingMarkUndo final : public TUndo {
+  std::vector<TXshCell> m_cells;
+  std::vector<int> m_oldMarks;
+  int m_newMark;
+
+public:
+  SetDrawingMarkUndo(std::vector<TXshCell> cells, int markId);
   void undo() const override;
   void redo() const override;
   int getSize() const override;
@@ -126,6 +141,7 @@ class CellArea final : public QWidget {
 
   void drawFrameMarker(QPainter &p, const QPoint &xy, QColor color,
                        bool isKeyFrame = false, bool isCamera = false);
+  void drawDrawingMarker(QPainter &p, int markId, const QRect &rect);
 
   void drawFocusCellBorder(QPainter &p);
 
@@ -188,6 +204,7 @@ protected slots:
   // Replace level with another level in the cast
   void onReplaceByCastedLevel(QAction *action);
   void onSetCellMark();
+  void onSetDrawingMark();
 };
 
 }  // namespace XsheetGUI

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -55,6 +55,7 @@
 // Tnz6 includes
 #include "cellselection.h"
 #include "columnselection.h"
+#include "filmstripselection.h"
 #include "keyframeselection.h"
 #include "celldata.h"
 #include "tapp.h"
@@ -66,6 +67,8 @@
 
 // Qt includes
 #include <QClipboard>
+
+#include <algorithm>
 
 // tcg includes
 #include "tcg/boost/range_utility.h"
@@ -2158,6 +2161,64 @@ public:
   }
 
 } ToggleXsheetCameraColumnCommand;
+
+//-----------------------------------------------------------------------------
+
+class SetDrawingMarkCommand final : public MenuItemHandler {
+  int m_markId;
+
+public:
+  explicit SetDrawingMarkCommand(int markId)
+      : MenuItemHandler(
+            ((std::string)MI_SetDrawingMark + std::to_string(markId)).c_str())
+      , m_markId(markId) {}
+
+  void execute() override {
+    TApp *app              = TApp::instance();
+    TSelection *selection  = app->getCurrentSelection()->getSelection();
+    if (!selection) return;
+
+    if (app->getCurrentFrame()->isEditingLevel()) {
+      auto *filmstripSelection = dynamic_cast<TFilmstripSelection *>(selection);
+      if (filmstripSelection) filmstripSelection->setDrawingMark(m_markId);
+      return;
+    }
+
+    auto *cellSelection = dynamic_cast<TCellSelection *>(selection);
+    if (!cellSelection) return;
+
+    int r0, c0, r1, c1;
+    cellSelection->getSelectedCells(r0, c0, r1, c1);
+    TXsheet *xsheet = app->getCurrentXsheet()->getXsheet();
+    std::vector<TXshCell> cells;
+    for (int col = std::max(0, c0); col <= c1; ++col) {
+      for (int row = r0; row <= r1; ++row) {
+        const TXshCell cell = xsheet->getCell(row, col);
+        if (cell.isEmpty() || !cell.getSimpleLevel() ||
+            std::find(cells.begin(), cells.end(), cell) != cells.end())
+          continue;
+        cells.push_back(cell);
+      }
+    }
+    if (cells.empty()) return;
+
+    auto *undo = new XsheetGUI::SetDrawingMarkUndo(std::move(cells), m_markId);
+    undo->redo();
+    TUndoManager::manager()->add(undo);
+  }
+};
+SetDrawingMarkCommand DrawingMarkCommand0(0);
+SetDrawingMarkCommand DrawingMarkCommand1(1);
+SetDrawingMarkCommand DrawingMarkCommand2(2);
+SetDrawingMarkCommand DrawingMarkCommand3(3);
+SetDrawingMarkCommand DrawingMarkCommand4(4);
+SetDrawingMarkCommand DrawingMarkCommand5(5);
+SetDrawingMarkCommand DrawingMarkCommand6(6);
+SetDrawingMarkCommand DrawingMarkCommand7(7);
+SetDrawingMarkCommand DrawingMarkCommand8(8);
+SetDrawingMarkCommand DrawingMarkCommand9(9);
+SetDrawingMarkCommand DrawingMarkCommand10(10);
+SetDrawingMarkCommand DrawingMarkCommand11(11);
 
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -841,6 +841,7 @@ void TXshSimpleLevel::eraseFrame(const TFrameId& fid) {
   }
 
   m_frames.erase(ft);
+  m_drawingMarks.erase(fid);
   getHookSet()->eraseFrame(fid);
 
   ImageManager* im = ImageManager::instance();
@@ -896,6 +897,7 @@ void TXshSimpleLevel::clearFrames() {
   m_editableRangeUserInfo.clear();
   m_renumberTable.clear();
   m_framesStatus.clear();
+  m_drawingMarks.clear();
 }
 
 //-----------------------------------------------------------------------------
@@ -952,6 +954,15 @@ void TXshSimpleLevel::loadData(TIStream& is) {
         m_properties->setColorSpaceGamma(colorSpaceGamma);
 
         if (isStopMotionLevel == 1) setIsReadOnly(true);
+      } else if (tagName == "drawingMarks") {
+        int markCount;
+        is >> markCount;
+        for (int i = 0; i < markCount; ++i) {
+          int frameNumber, markId;
+          is >> frameNumber >> markId;
+          setDrawingMark(TFrameId(frameNumber), markId);
+        }
+        is.matchEndTag();
       } else {
         throw TException("unexpected tag " + tagName);
       }
@@ -1400,6 +1411,13 @@ void TXshSimpleLevel::saveData(TOStream& os) {
 
   os.child("path") << m_path;
   if (m_scannedPath != TFilePath()) os.child("scannedPath") << m_scannedPath;
+  if (!m_drawingMarks.empty()) {
+    os.openChild("drawingMarks");
+    os << static_cast<int>(m_drawingMarks.size());
+    for (const auto &[fid, markId] : m_drawingMarks)
+      os << fid.getNumber() << markId;
+    os.closeChild();
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -2145,6 +2163,28 @@ void TXshSimpleLevel::renumber(const std::vector<TFrameId>& fids) {
   m_properties->setDirtyFlag(true);
 
   if (getHookSet()) getHookSet()->renumber(table);
+
+  const std::map<TFrameId, int> oldDrawingMarks = m_drawingMarks;
+  m_drawingMarks.clear();
+  for (const auto &[fid, markId] : oldDrawingMarks)
+    m_drawingMarks[table[fid]] = markId;
+}
+
+//-----------------------------------------------------------------------------
+
+int TXshSimpleLevel::getDrawingMark(const TFrameId &fid) const {
+  const auto it = m_drawingMarks.find(fid);
+  return it == m_drawingMarks.end() ? -1 : it->second;
+}
+
+//-----------------------------------------------------------------------------
+
+void TXshSimpleLevel::setDrawingMark(const TFrameId &fid, int markId) {
+  if (markId < 0) {
+    m_drawingMarks.erase(fid);
+    return;
+  }
+  m_drawingMarks[fid] = markId;
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzqt/menubarcommand.cpp
+++ b/toonz/sources/toonzqt/menubarcommand.cpp
@@ -128,6 +128,7 @@ void CommandManager::define(CommandId id, CommandType type,
        (node->m_handler || node->m_qaction->actionGroup() != 0)) ||
       node->m_type == MiscCommandType ||
       node->m_type == ToolModifierCommandType ||
+      node->m_type == DrawingMarkCommandType ||
       node->m_type == CellMarkCommandType);
   node->m_iconSVGName = iconSVGName;
 


### PR DESCRIPTION
## Summary
- add persistent per-drawing marks using the existing Scene Settings mark palette
- show and edit marks in Filmstrip and Xsheet/Timeline, including multi-cell selections
- preserve marks through frame copy, cut, paste, clear, remove, and renumber operations
- expose twelve configurable drawing-mark shortcut commands

## Verification
- compiled all affected translation units with the existing CMake compilation database
- `git diff --check`

The full application link is not available on this ARM machine because the checked-in SuperLU binary is Intel-only.