### PR TITLE
[T2D-109] Add selective Toonz Raster selection

### DIFF
--- a/toonz/sources/include/tools/rasterselection.h
+++ b/toonz/sources/include/tools/rasterselection.h
@@ -33,6 +33,10 @@ class TTileSetCM32;
 class StrokesData;
 class RasterImageData;
 
+#define LINES L"Lines"
+#define AREAS L"Areas"
+#define ALL L"Lines & Areas"
+
 //=============================================================================
 // RasterSelection
 //! Selection of TToonzImage and TRasterImage.
@@ -58,6 +62,9 @@ class DVAPI RasterSelection final : public TSelection {
   bool m_createdFrame;
   bool m_createdLevel;
   bool m_renumberedLevel;
+
+  TPixelCM32 m_selectivePixelCM32;
+  std::wstring m_selectiveMode;
 
 private:
   bool pasteSelection(const RasterImageData *data);
@@ -153,6 +160,14 @@ Can be different from getSelectionBound() after a free deform transformation. */
   bool isTransformed();
 
   bool isEditable();
+
+  void setSelectivePixelCM32(const TPixelCM32 &pixel,
+                             const std::wstring &mode) {
+    m_selectivePixelCM32 = pixel;
+    m_selectiveMode      = mode;
+  }
+  TPixelCM32 getSelectivePixelCM32() const { return m_selectivePixelCM32; }
+  const std::wstring &getSelectiveMode() const { return m_selectiveMode; }
 };
 
 #endif  // RASTER_SELECTION_H

--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -371,6 +371,9 @@ class SelectionToolOptionsBox final : public ToolOptionsBox,
   TTool *m_tool;
 
   ToolOptionCheckbox *m_setSaveboxCheckbox;
+  ToolOptionCheckbox *m_selective;
+  ToolOptionCombo *m_selectiveMode;
+  QLabel *m_selectiveModeLabel;
   bool m_isVectorSelction;
   QLabel *m_scaleXLabel;
   SelectionScaleField *m_scaleXField;

--- a/toonz/sources/tnztools/rasterselection.cpp
+++ b/toonz/sources/tnztools/rasterselection.cpp
@@ -96,10 +96,45 @@ TRectD intersection(const TRectD &area, const TImageP image) {
 
 //-----------------------------------------------------------------------------
 
+template <class PIXEL>
+void emptyPixel(PIXEL &pixel, const PIXEL &emptyPixel,
+                const PIXEL &selectivePixel, const std::wstring &selectiveMode) {
+  pixel = emptyPixel;
+}
+
+void emptyPixel(TPixelCM32 &pixel, const TPixelCM32 &emptyPixel,
+                const TPixelCM32 &selectivePixel,
+                const std::wstring &selectiveMode) {
+  if (selectivePixel == TPixelCM32()) {
+    pixel = emptyPixel;
+    return;
+  }
+
+  if (selectivePixel.getInk() == pixel.getInk() &&
+      (selectiveMode == LINES || selectiveMode == ALL)) {
+    pixel.setInk(emptyPixel.getInk());
+    if (pixel.getPaint()) {
+      if (!pixel.getTone())
+        pixel.setPaint(emptyPixel.getPaint());
+      else
+        pixel.setTone(255);
+    }
+  }
+  if (selectivePixel.getPaint() == pixel.getPaint() &&
+      (selectiveMode == AREAS || selectiveMode == ALL))
+    pixel.setPaint(emptyPixel.getPaint());
+  if (pixel.getInk() == emptyPixel.getInk() &&
+      pixel.getPaint() == emptyPixel.getPaint())
+    pixel.setTone(emptyPixel.getTone());
+}
+
+//-----------------------------------------------------------------------------
+
 // The stroke is in raster coordinates
 template <class PIXEL1, class PIXEL2>
 TRasterPT<PIXEL1> getImageFromStroke(TRasterPT<PIXEL2> ras,
-                                     const TStroke &stroke) {
+                                     const TStroke &stroke,
+                                     RasterSelection &selection) {
   TRectD regionsBoxD = stroke.getBBox();
   // E' volutamente allargato di un pixel!
   TRect regionsBox(tfloor(regionsBoxD.x0), tfloor(regionsBoxD.y0),
@@ -114,6 +149,8 @@ TRasterPT<PIXEL1> getImageFromStroke(TRasterPT<PIXEL2> ras,
   app.addStroke(new TStroke(stroke));
   app.findRegions();
   int reg, j, k, y;
+  const TPixelCM32 selectivePixel = selection.getSelectivePixelCM32();
+  const std::wstring &selectiveMode = selection.getSelectiveMode();
   ras->lock();
   for (reg = 0; reg < (int)app.getRegionCount(); reg++) {
     // For each region, pixels inside the region are copied in buffer!
@@ -144,7 +181,26 @@ TRasterPT<PIXEL1> getImageFromStroke(TRasterPT<PIXEL2> ras,
             TPixelCM32 *bottomPix =
                 (TPixelCM32 *)bufferLine + k - regionsBox.x0;
             TPixelCM32 *topPix = (TPixelCM32 *)selectedLine + k;
-            *bottomPix         = *topPix;
+            if (selectivePixel == TPixelCM32())
+              *bottomPix = *topPix;
+            else {
+              if (selectivePixel.getInk() == topPix->getInk() &&
+                  (selectiveMode == LINES || selectiveMode == ALL)) {
+                bottomPix->setInk(topPix->getInk());
+                bottomPix->setTone(topPix->getTone());
+              }
+              if (selectivePixel.getPaint() == topPix->getPaint() &&
+                  (selectiveMode == AREAS || selectiveMode == ALL)) {
+                bottomPix->setPaint(
+                    (!bottomPix->getInk() && topPix->getTone() < 70)
+                        ? 0
+                        : topPix->getPaint());
+                bottomPix->setTone(!bottomPix->getInk() ? 255
+                                                        : topPix->getTone());
+              }
+              if (bottomPix->getInk() == 0 && bottomPix->getPaint() == 0)
+                *bottomPix = TPixelCM32();
+            }
           } else if (buffer32 && ras32) {
             TPixel32 *bottomPix = (TPixel32 *)bufferLine + k - regionsBox.x0;
             TPixel32 *topPix    = (TPixel32 *)selectedLine + k;
@@ -181,7 +237,8 @@ TRasterPT<PIXEL1> getImageFromSelection(TRasterPT<PIXEL2> &ras,
   for (i = 0; i < strokes.size(); i++) {
     TStroke stroke = strokes[i];
     stroke.transform(TTranslation(ras->getCenterD()));
-    TRasterPT<PIXEL1> app = getImageFromStroke<PIXEL1, PIXEL2>(ras, stroke);
+    TRasterPT<PIXEL1> app =
+        getImageFromStroke<PIXEL1, PIXEL2>(ras, stroke, selection);
     if (!app) continue;
     TRectD strokeRectD = stroke.getBBox();
     TRect strokeRect(tfloor(strokeRectD.x0), tfloor(strokeRectD.y0),
@@ -221,7 +278,9 @@ TRasterP getImageFromSelection(const TImageP &image,
 template <typename PIXEL>
 void deleteSelectionWithoutUndo(TRasterPT<PIXEL> &ras,
                                 const std::vector<TStroke> &strokes,
-                                PIXEL emptyValue) {
+                                const PIXEL &emptyValue,
+                                const PIXEL &selectivePixel,
+                                const std::wstring &selectiveMode) {
   if (!ras) return;
   unsigned int i;
   for (i = 0; i < strokes.size(); i++) {
@@ -258,7 +317,9 @@ void deleteSelectionWithoutUndo(TRasterPT<PIXEL> &ras,
           if (intersections[j] == intersections[j + 1]) continue;
           int from = std::max(tfloor(intersections[j]), bBox.x0);
           int to   = std::min(tceil(intersections[j + 1]), bBox.x1);
-          for (k = from; k <= to; k++) *(selectedLine + k) = emptyValue;
+          for (k = from; k <= to; ++k)
+            emptyPixel(*(selectedLine + k), emptyValue, selectivePixel,
+                       selectiveMode);
         }
       }
     }
@@ -269,18 +330,23 @@ void deleteSelectionWithoutUndo(TRasterPT<PIXEL> &ras,
 //-----------------------------------------------------------------------------
 
 void deleteSelectionWithoutUndo(const TImageP &image,
-                                const std::vector<TStroke> &strokes) {
+                                const std::vector<TStroke> &strokes,
+                                const TPixelCM32 &selectivePixel,
+                                const std::wstring &selectiveMode) {
   if (TToonzImageP toonzImage = (TToonzImageP)image) {
     TRasterPT<TPixelCM32> ras = toonzImage->getRaster();
-    deleteSelectionWithoutUndo<TPixelCM32>(ras, strokes, TPixelCM32());
+    deleteSelectionWithoutUndo<TPixelCM32>(ras, strokes, TPixelCM32(),
+                                           selectivePixel, selectiveMode);
   }
   if (TRasterImageP rasterImage = (TRasterImageP)image) {
     TRasterP ras = rasterImage->getRaster();
     if (TRaster32P ras32 = (TRaster32P)ras)
       deleteSelectionWithoutUndo<TPixel32>(ras32, strokes,
-                                           TPixel32::Transparent);
+                                           TPixel32::Transparent, TPixel32(),
+                                           selectiveMode);
     if (TRasterGR8P rasGR8 = (TRasterGR8P)ras)
-      deleteSelectionWithoutUndo<TPixelGR8>(rasGR8, strokes, TPixelGR8::White);
+      deleteSelectionWithoutUndo<TPixelGR8>(rasGR8, strokes, TPixelGR8::White,
+                                            TPixelGR8(), selectiveMode);
   }
 }
 
@@ -315,20 +381,28 @@ class UndoDeleteSelection final : public TUndo {
   TPoint m_erasePoint;
   std::vector<TStroke> m_strokes;
   TTool *m_tool;
+  TPixelCM32 m_selectivePixel;
+  std::wstring m_selectiveMode;
 
 public:
-  UndoDeleteSelection(RasterSelection *selection, TXshSimpleLevel *level)
+  UndoDeleteSelection(RasterSelection *selection, TXshSimpleLevel *level,
+                      const TPixelCM32 &selectivePixel,
+                      const std::wstring &selectiveMode)
       : TUndo()
       , m_level(level)
       , m_frameId(selection->getFrameId())
-      , m_strokes(selection->getOriginalStrokes()) {
+      , m_strokes(selection->getOriginalStrokes())
+      , m_selectivePixel(selectivePixel)
+      , m_selectiveMode(selectiveMode) {
     TImageP image   = m_level->getFrame(m_frameId, true);
     m_erasedImageId = "UndoDeleteSelection" + std::to_string(m_id++);
     TRasterP ras    = getRaster(image);
     TRasterP erasedRas;
-    if (!selection->isFloating())
+    if (!selection->isFloating()) {
+      selection->setSelectivePixelCM32(TPixelCM32(), ALL);
       erasedRas = TRasterP(getImageFromSelection(image, *selection));
-    else
+      selection->setSelectivePixelCM32(m_selectivePixel, m_selectiveMode);
+    } else
       erasedRas = TRasterP(selection->getOriginalFloatingSelection());
     TImageP erasedImage;
     if (TRasterCM32P toonzRas = (TRasterCM32P)(erasedRas))
@@ -366,7 +440,8 @@ public:
     TImageP image       = m_level->getFrame(m_frameId, true);
     TImageP erasedImage = TImageCache::instance()->get(m_erasedImageId, false);
     if (!erasedImage) return;
-    deleteSelectionWithoutUndo(image, m_strokes);
+    deleteSelectionWithoutUndo(image, m_strokes, m_selectivePixel,
+                               m_selectiveMode);
 
     ToolUtils::updateSaveBox(m_level, m_frameId);
     if (!m_tool) return;
@@ -375,6 +450,8 @@ public:
   }
 
   int getSize() const override { return sizeof(*this); }
+
+  QString getHistoryString() override { return QObject::tr("Delete"); }
 };
 
 int UndoDeleteSelection::m_id = 0;
@@ -442,11 +519,15 @@ class UndoPasteFloatingSelection final : public ToolUtils::TToolUndo {
 
   TTool *m_tool;
   TFrameId m_frameId;
+  TPixelCM32 m_selectivePixel;
+  std::wstring m_selectiveMode;
 
 public:
   UndoPasteFloatingSelection(RasterSelection *currentSelection,
                              TXshSimpleLevel *sl, TPalette *oldPalette,
-                             bool noAntialiasing)
+                             bool noAntialiasing,
+                             const TPixelCM32 &selectivePixel,
+                             const std::wstring &selectiveMode)
       : TToolUndo(sl, currentSelection->getFrameId(),
                   currentSelection->wasFrameCreated(),
                   currentSelection->wasLevelCreated(), oldPalette,
@@ -459,7 +540,9 @@ public:
       , m_isPastedSelection(currentSelection->isPastedSelection())
       , m_noAntialiasing(noAntialiasing)
       , m_undoImageId("")
-      , m_frameId(currentSelection->getFrameId()) {
+      , m_frameId(currentSelection->getFrameId())
+      , m_selectivePixel(selectivePixel)
+      , m_selectiveMode(selectiveMode) {
     TImageP image(currentSelection->getCurrentImage());
     if (!image) return;
 
@@ -577,7 +660,9 @@ public:
     TXshSimpleLevelP sl(m_imageCell.getSimpleLevel());
     const TFrameId &fid = m_imageCell.m_frameId;
 
-    if (!m_isPastedSelection) deleteSelectionWithoutUndo(image, m_strokes);
+    if (!m_isPastedSelection)
+      deleteSelectionWithoutUndo(image, m_strokes, m_selectivePixel,
+                                 m_selectiveMode);
 
     TRasterP ras = getRaster(image);
     pasteFloatingSelectionWithoutUndo(image, floatingRas, m_transformation,
@@ -907,7 +992,9 @@ RasterSelection::RasterSelection()
     , m_noAntialiasing(false)
     , m_createdFrame(false)
     , m_createdLevel(false)
-    , m_renumberedLevel(false) {
+    , m_renumberedLevel(false)
+    , m_selectivePixelCM32(TPixelCM32())
+    , m_selectiveMode(LINES) {
   m_strokes.clear();
   m_originalStrokes.clear();
 }
@@ -930,6 +1017,8 @@ RasterSelection::RasterSelection(const RasterSelection &src)
     , m_createdFrame(src.m_createdFrame)
     , m_createdLevel(src.m_createdLevel)
     , m_renumberedLevel(src.m_renumberedLevel)
+    , m_selectivePixelCM32(src.m_selectivePixelCM32)
+    , m_selectiveMode(src.m_selectiveMode)
 
 {
   setView(src.getView());
@@ -1057,9 +1146,13 @@ void RasterSelection::makeFloating() {
 
   if (!isEditable()) return;
 
-  m_floatingSelection         = getImageFromSelection(m_currentImage, *this);
-  m_originalfloatingSelection = m_floatingSelection->clone();
-  deleteSelectionWithoutUndo(m_currentImage, m_strokes);
+  const TPixelCM32 selectivePixel = m_selectivePixelCM32;
+  m_selectivePixelCM32            = TPixelCM32();
+  m_originalfloatingSelection     = getImageFromSelection(m_currentImage, *this);
+  m_selectivePixelCM32            = selectivePixel;
+  m_floatingSelection             = getImageFromSelection(m_currentImage, *this);
+  deleteSelectionWithoutUndo(m_currentImage, m_strokes, m_selectivePixelCM32,
+                             m_selectiveMode);
 
   ToolUtils::updateSaveBox();
   TTool *tool = TTool::getApplication()->getCurrentTool()->getTool();
@@ -1081,13 +1174,15 @@ void RasterSelection::pasteFloatingSelection() {
   if (m_transformationCount > 0 || m_isPastedSelection)
     TUndoManager::manager()->add(new UndoPasteFloatingSelection(
         this, m_currentImageCell.getSimpleLevel(), m_oldPalette.getPointer(),
-        m_noAntialiasing));
+        m_noAntialiasing, m_selectivePixelCM32, m_selectiveMode));
   else if (m_transformationCount == 0)
     TUndoManager::manager()->popUndo(-1, true);
 
   TRectD wRect = getSelectionBbox();
-  pasteFloatingSelectionWithoutUndo(m_currentImage, m_floatingSelection,
-                                    m_affine, wRect, m_noAntialiasing);
+  const TRasterP selectionToPaste =
+      m_transformationCount ? m_floatingSelection : m_originalfloatingSelection;
+  pasteFloatingSelectionWithoutUndo(m_currentImage, selectionToPaste, m_affine,
+                                    wRect, m_noAntialiasing);
 
   ToolUtils::updateSaveBox(m_currentImageCell.getSimpleLevel(),
                            m_currentImageCell.getFrameId());
@@ -1121,10 +1216,12 @@ void RasterSelection::deleteSelection() {
       TUndoManager::manager()->popUndo(m_transformationCount);
   }
   if (!isPastedSelection() && !isEmpty())
-    TUndoManager::manager()->add(new UndoDeleteSelection(this, level));
+    TUndoManager::manager()->add(new UndoDeleteSelection(
+        this, level, m_selectivePixelCM32, m_selectiveMode));
 
   if (!isFloating())
-    deleteSelectionWithoutUndo(m_currentImage, m_strokes);
+    deleteSelectionWithoutUndo(m_currentImage, m_strokes, m_selectivePixelCM32,
+                               m_selectiveMode);
   else if (m_oldPalette)
     m_currentImage->getPalette()->assign(m_oldPalette.getPointer());
   m_floatingSelection         = TRasterP();

--- a/toonz/sources/tnztools/rasterselectiontool.cpp
+++ b/toonz/sources/tnztools/rasterselectiontool.cpp
@@ -461,6 +461,9 @@ void DragSelectionTool::RasterScaleTool::leftButtonUp(const TPointD &pos,
 
 TEnv::IntVar ModifySavebox("ModifySavebox", 0);
 TEnv::IntVar NoAntialiasing("NoAntialiasing", 0);
+TEnv::IntVar RasterSelectionSelective("SelectionToolInknpaintTypeSelective", 0);
+TEnv::StringVar RasterSelectionSelectiveMode(
+    "SelectionToolInknpaintTypeSelectiveMode", "Lines");
 
 //=============================================================================
 // RasterSelectionTool
@@ -472,7 +475,18 @@ RasterSelectionTool::RasterSelectionTool(int targetType)
     , m_selectionFreeDeformer(0)
     , m_noAntialiasing("No Antialiasing", false)
     , m_modifySavebox("Modify Savebox", false)
+    , m_selective("Selective", false)
+    , m_selectiveMode("Mode:")
     , m_setSaveboxTool(0) {
+  if (m_targetType & ToonzImage) {
+    m_prop.bind(m_selective);
+    m_selective.setId("Selective");
+    m_selectiveMode.addValue(LINES);
+    m_selectiveMode.addValue(AREAS);
+    m_selectiveMode.addValue(ALL);
+    m_prop.bind(m_selectiveMode);
+    m_selectiveMode.setId("Mode");
+  }
   m_prop.bind(m_noAntialiasing);
   m_rasterSelection.setView(this);
   if (m_targetType & ToonzImage) {
@@ -600,6 +614,17 @@ void RasterSelectionTool::leftButtonDown(const TPointD &pos,
     m_setSaveboxTool->leftButtonDown(pos);
     return;
   }
+
+  TPixelCM32 selectivePixel;
+  std::wstring selectiveMode = ALL;
+  if (m_selective.getValue()) {
+    const int styleId =
+        TTool::getApplication()->getCurrentLevelStyleIndex();
+    selectivePixel = TPixelCM32(styleId, styleId, 0);
+    selectiveMode  = m_selectiveMode.getValue();
+  }
+  m_rasterSelection.setSelectivePixelCM32(selectivePixel, selectiveMode);
+
   SelectionTool::leftButtonDown(pos, e);
 }
 
@@ -1006,8 +1031,12 @@ void RasterSelectionTool::decreaseTransformationCount() {
 
 void RasterSelectionTool::onActivate() {
   if (m_firstTime) {
-    if (m_targetType & ToonzImage)
+    if (m_targetType & ToonzImage) {
       m_modifySavebox.setValue(ModifySavebox ? 1 : 0);
+      m_selective.setValue(RasterSelectionSelective ? 1 : 0);
+      m_selectiveMode.setValue(
+          ::to_wstring(RasterSelectionSelectiveMode.getValue()));
+    }
   }
 
   SelectionTool::onActivate();
@@ -1020,7 +1049,9 @@ bool RasterSelectionTool::onPropertyChanged(std::string propertyName) {
 
   if (SelectionTool::onPropertyChanged(propertyName)) return true;
   if (m_targetType & ToonzImage) {
-    ModifySavebox = (int)(m_modifySavebox.getValue());
+    ModifySavebox                = (int)(m_modifySavebox.getValue());
+    RasterSelectionSelective     = (int)(m_selective.getValue());
+    RasterSelectionSelectiveMode = ::to_string(m_selectiveMode.getValue());
     invalidate();
   }
   if (propertyName == m_noAntialiasing.getName()) {
@@ -1034,8 +1065,14 @@ bool RasterSelectionTool::onPropertyChanged(std::string propertyName) {
 //-----------------------------------------------------------------------------
 
 void RasterSelectionTool::updateTranslation() {
-  if (m_targetType & ToonzImage)
+  if (m_targetType & ToonzImage) {
     m_modifySavebox.setQStringName(tr("Modify Savebox"));
+    m_selective.setQStringName(tr("Selective"));
+    m_selectiveMode.setQStringName(tr("Mode:"));
+    m_selectiveMode.setItemUIName(LINES, tr("Lines"));
+    m_selectiveMode.setItemUIName(AREAS, tr("Areas"));
+    m_selectiveMode.setItemUIName(ALL, tr("Lines & Areas"));
+  }
 
   m_noAntialiasing.setQStringName(tr("No Antialiasing"));
   SelectionTool::updateTranslation();

--- a/toonz/sources/tnztools/rasterselectiontool.h
+++ b/toonz/sources/tnztools/rasterselectiontool.h
@@ -192,6 +192,8 @@ class RasterSelectionTool final : public SelectionTool {
   //! Used in ToonzRasterImage to switch from selection tool to modify savebox
   //! tool.
   TBoolProperty m_modifySavebox;
+  TBoolProperty m_selective;
+  TEnumProperty m_selectiveMode;
   SetSaveboxTool *m_setSaveboxTool;
   TBoolProperty m_noAntialiasing;
 

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -1115,7 +1115,10 @@ SelectionToolOptionsBox::SelectionToolOptionsBox(QWidget *parent, TTool *tool,
     : ToolOptionsBox(parent)
     , m_tool(tool)
     , m_isVectorSelction(false)
-    , m_setSaveboxCheckbox(0) {
+    , m_setSaveboxCheckbox(0)
+    , m_selective(0)
+    , m_selectiveMode(0)
+    , m_selectiveModeLabel(0) {
   TPropertyGroup *props = tool->getProperties(0);
   assert(props->getPropertyCount() > 0);
 
@@ -1143,6 +1146,13 @@ SelectionToolOptionsBox::SelectionToolOptionsBox(QWidget *parent, TTool *tool,
   m_moveYField = new SelectionMoveField(selectionTool, 1, "Move Y");
 
   if (rasterSelectionTool) {
+    m_selective =
+        dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Selective"));
+    m_selectiveMode =
+        dynamic_cast<ToolOptionCombo *>(m_controls.value("Mode:"));
+    if (m_selectiveMode)
+      m_selectiveModeLabel = m_labels.value(m_selectiveMode->propertyName());
+
     TBoolProperty *modifySetSaveboxProp =
         rasterSelectionTool->getModifySaveboxProperty();
     if (modifySetSaveboxProp)
@@ -1330,6 +1340,11 @@ void SelectionToolOptionsBox::updateStatus() {
       if (w && w != m_setSaveboxCheckbox) w->setEnabled(!disable);
     }
     if (disable) return;
+  }
+
+  if (m_selective && m_selectiveMode && m_selectiveModeLabel) {
+    m_selectiveModeLabel->setEnabled(m_selective->isChecked());
+    m_selectiveMode->setEnabled(m_selective->isChecked());
   }
 
   m_scaleXField->updateStatus();


### PR DESCRIPTION
## Summary
- add a Selective option to the Smart Raster Selection Tool
- select, cut, delete, move, paste, and undo only the active style’s lines, areas, or both
- persist the selection mode and enable its mode control only when Selective is active

## Verification
- compiled `rasterselection.cpp`, `rasterselectiontool.cpp`, and `tooloptions.cpp` with the existing CMake compilation database
- `git diff --check`

The raster-selection compilation reports two existing enum-comparison warnings outside this change.