### PR TITLE
[T2D-110] Add eraser pressure sensitivity

### DIFF
--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -587,7 +587,8 @@ protected slots:
 class EraserToolOptionsBox final : public ToolOptionsBox {
   Q_OBJECT
 
-  ToolOptionCheckbox *m_pencilMode, *m_invertMode, *m_multiFrameMode;
+  ToolOptionCheckbox *m_pencilMode, *m_invertMode, *m_multiFrameMode,
+      *m_pressure;
   ToolOptionCombo *m_toolType, *m_colorMode;
   QLabel *m_hardnessLabel;
   ToolOptionSlider *m_hardnessField;

--- a/toonz/sources/tnztools/fullcolorerasertool.cpp
+++ b/toonz/sources/tnztools/fullcolorerasertool.cpp
@@ -47,12 +47,14 @@ using namespace ToolUtils;
 #define POLYLINEERASE L"Polyline"
 #define MULTIARCERASE L"MultiArc"
 
+TEnv::DoubleVar FullcolorEraseMinSize("FullcolorEraseMinSize", 1);
 TEnv::DoubleVar FullcolorEraseSize("FullcolorEraseSize", 5);
 TEnv::DoubleVar FullcolorEraseHardness("FullcolorEraseHardness", 100);
 TEnv::DoubleVar FullcolorEraserOpacity("FullcolorEraserOpacity", 100);
 TEnv::StringVar FullcolorEraserType("FullcolorEraseType", "Normal");
 TEnv::IntVar FullcolorEraserInvert("FullcolorEraseInvert", 0);
 TEnv::IntVar FullcolorEraserRange("FullcolorEraseRange", 0);
+TEnv::IntVar FullcolorEraserPressure("FullcolorEraserPressure", 1);
 
 //**********************************************************************************
 //    Local namespace  stuff
@@ -60,9 +62,8 @@ TEnv::IntVar FullcolorEraserRange("FullcolorEraseRange", 0);
 
 namespace {
 
-int computeThickness(int pressure, const TIntPairProperty &property) {
-  double p   = pressure / 255.0;
-  double t   = p * p * p;
+int computeThickness(double pressure, const TIntPairProperty &property) {
+  double t   = pressure * pressure * pressure;
   int thick0 = property.getValue().first;
   int thick1 = property.getValue().second;
 
@@ -627,7 +628,8 @@ public:
 private:
   TPropertyGroup m_prop;
 
-  TIntProperty m_size;
+  TIntPairProperty m_size;
+  TBoolProperty m_pressure;
   TDoubleProperty m_opacity;
   TDoubleProperty m_hardness;
   TEnumProperty m_eraseType;
@@ -671,7 +673,7 @@ private:
 
 FullColorEraserTool::FullColorEraserTool(std::string name)
     : TTool(name)
-    , m_size("Size:", 1, 1000, 5, false)
+    , m_size("Size:", 1, 1000, 1, 5, false)
     , m_opacity("Opacity:", 0, 100, 100)
     , m_hardness("Hardness:", 0, 100, 100)
     , m_eraseType("Type:")
@@ -685,7 +687,8 @@ FullColorEraserTool::FullColorEraserTool(std::string name)
     , m_firstTime(true)
     , m_selecting(false)
     , m_firstFrameSelected(false)
-    , m_isXsheetCell(false) {
+    , m_isXsheetCell(false)
+    , m_pressure("Pressure", true) {
   bind(TTool::RasterImage);
 
   m_size.setNonLinearSlider();
@@ -694,6 +697,7 @@ FullColorEraserTool::FullColorEraserTool(std::string name)
   m_prop.bind(m_hardness);
   m_prop.bind(m_opacity);
   m_prop.bind(m_eraseType);
+  m_prop.bind(m_pressure);
   m_prop.bind(m_invertOption);
   m_prop.bind(m_multi);
 
@@ -704,6 +708,7 @@ FullColorEraserTool::FullColorEraserTool(std::string name)
   m_eraseType.addValue(MULTIARCERASE);
 
   m_eraseType.setId("Type");
+  m_pressure.setId("PressureSensitivity");
   m_invertOption.setId("Invert");
   m_multi.setId("FrameRange");
   m_multiArcPrimitive = MultiArcPrimitive(this);
@@ -717,6 +722,7 @@ FullColorEraserTool::~FullColorEraserTool() { delete m_firstStroke; }
 
 void FullColorEraserTool::updateTranslation() {
   m_size.setQStringName(tr("Size:"));
+  m_pressure.setQStringName(tr("Pressure"));
   m_opacity.setQStringName(tr("Opacity:"));
   m_hardness.setQStringName(tr("Hardness:"));
 
@@ -736,16 +742,19 @@ void FullColorEraserTool::updateTranslation() {
 void FullColorEraserTool::onActivate() {
   if (m_firstTime) {
     m_firstTime = false;
-    m_size.setValue(FullcolorEraseSize);
+    m_size.setValue(
+        TIntPairProperty::Value(FullcolorEraseMinSize, FullcolorEraseSize));
     m_opacity.setValue(FullcolorEraserOpacity);
     m_hardness.setValue(FullcolorEraseHardness);
     m_eraseType.setValue(::to_wstring(FullcolorEraserType.getValue()));
+    m_pressure.setValue((bool)FullcolorEraserPressure);
     m_invertOption.setValue((bool)FullcolorEraserInvert);
     m_multi.setValue((bool)FullcolorEraserRange);
     m_firstTime = false;
   }
 
-  m_brushPad = getBrushPad(m_size.getValue(), m_hardness.getValue() * 0.01);
+  m_brushPad =
+      getBrushPad(m_size.getValue().second, m_hardness.getValue() * 0.01);
 
   // setting m_level in resetMulti() will take care when the tool is switched
   // via shortcut ( i.e. the case skipping onEnter() )
@@ -778,9 +787,12 @@ void FullColorEraserTool::leftButtonDown(const TPointD &pos,
     m_workRaster->clear();
     m_backUpRas = ras->clone();
 
-    int maxThick      = m_size.getValue();
+    int maxThick  = m_size.getValue().second;
+    int thickness = (m_pressure.getValue() && e.isTablet())
+                        ? computeThickness(e.m_pressure, m_size)
+                        : maxThick;
     TPointD rasCenter = ras->getCenterD();
-    TThickPoint point(pos + rasCenter, maxThick);  //???
+    TThickPoint point(pos + rasCenter, thickness);
     TPointD halfThick(maxThick * 0.5, maxThick * 0.5);
     invalidateRect = TRectD(pos - halfThick, pos + halfThick);
 
@@ -790,7 +802,7 @@ void FullColorEraserTool::leftButtonDown(const TPointD &pos,
     m_tileSet   = new TTileSetFullColor(ras->getSize());
     m_tileSaver = new TTileSaverFullColor(ras, m_tileSet);
     m_brush =
-        new BluredBrush(m_workRaster, m_size.getValue(), m_brushPad, false);
+        new BluredBrush(m_workRaster, maxThick, m_brushPad, false);
     TRect bbox = m_brush->getBoundFromPoints(m_points);
     m_tileSaver->save(bbox);
     m_brush->addPoint(point, 1);
@@ -849,7 +861,10 @@ void FullColorEraserTool::leftButtonDrag(const TPointD &pos,
   TRasterImageP ri = (TRasterImageP)getImage(true);
   if (!ri) return;
   if (m_eraseType.getValue() == NORMALERASE) {
-    double thickness  = m_size.getValue();
+    int maxThick  = m_size.getValue().second;
+    int thickness = (m_pressure.getValue() && e.isTablet())
+                        ? computeThickness(e.m_pressure, m_size)
+                        : maxThick;
     TPointD rasCenter = ri->getRaster()->getCenterD();
     TThickPoint point(pos + rasCenter, thickness);
 
@@ -874,7 +889,7 @@ void FullColorEraserTool::leftButtonDrag(const TPointD &pos,
       std::vector<TThickPoint> points;
       points.push_back(pa);
       points.push_back(mid);
-      invalidateRect = ToolUtils::getBounds(points, thickness);
+      invalidateRect = ToolUtils::getBounds(points, maxThick);
       bbox           = m_brush->getBoundFromPoints(points);
       m_tileSaver->save(bbox);
       m_brush->addArc(pa, (mid + pa) * 0.5, mid, 1, 1);
@@ -883,7 +898,7 @@ void FullColorEraserTool::leftButtonDrag(const TPointD &pos,
       points.push_back(m_points[m - 4]);
       points.push_back(old);
       points.push_back(mid);
-      invalidateRect = ToolUtils::getBounds(points, thickness);
+      invalidateRect = ToolUtils::getBounds(points, maxThick);
       bbox           = m_brush->getBoundFromPoints(points);
       m_tileSaver->save(bbox);
       m_brush->addArc(m_points[m - 4], old, mid, 1, 1);
@@ -920,9 +935,13 @@ void FullColorEraserTool::leftButtonUp(const TPointD &pos,
   TRasterImageP ri        = (TRasterImageP)getImage(true);
   if (!ri) return;
   if (m_eraseType.getValue() == NORMALERASE) {
+    int maxThick  = m_size.getValue().second;
+    int thickness = (m_pressure.getValue() && e.isTablet())
+                        ? computeThickness(e.m_pressure, m_size)
+                        : maxThick;
     if (m_points.size() != 1) {
       TPointD rasCenter = ri->getRaster()->getCenterD();
-      TThickPoint point(pos + rasCenter, m_size.getValue());
+      TThickPoint point(pos + rasCenter, thickness);
       m_points.push_back(point);
       int m = m_points.size();
       std::vector<TThickPoint> points;
@@ -934,7 +953,7 @@ void FullColorEraserTool::leftButtonUp(const TPointD &pos,
       m_brush->addArc(points[0], points[1], points[2], 1, 1);
       double opacity = m_opacity.getValue() * 0.01;
       m_brush->eraseDrawing(ri->getRaster(), m_backUpRas, bbox, opacity);
-      TRectD invalidateRect = ToolUtils::getBounds(points, m_size.getValue());
+      TRectD invalidateRect = ToolUtils::getBounds(points, maxThick);
       invalidate(invalidateRect.enlarge(2) - rasCenter);
     }
 
@@ -954,7 +973,7 @@ void FullColorEraserTool::leftButtonUp(const TPointD &pos,
     TXshSimpleLevelP simLevel = level->getSimpleLevel();
     TFrameId frameId          = getCurrentFid();
     TUndoManager::manager()->add(new FullColorEraserUndo(
-        m_tileSet, m_points, simLevel.getPointer(), frameId, m_size.getValue(),
+        m_tileSet, m_points, simLevel.getPointer(), frameId, maxThick,
         m_hardness.getValue() * 0.01, opacity));
     notifyImageChanged();
   } else if (m_eraseType.getValue() == RECTERASE) {
@@ -1245,17 +1264,24 @@ void FullColorEraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   struct Locals {
     FullColorEraserTool *m_this;
 
-    void setValue(TIntProperty &prop, int value) {
+    void setValue(TIntPairProperty &prop,
+                  const TIntPairProperty::Value &value) {
       prop.setValue(value);
 
       m_this->onPropertyChanged(prop.getName());
       TTool::getApplication()->getCurrentTool()->notifyToolChanged();
     }
 
-    void addValue(TIntProperty &prop, double add) {
-      const TIntProperty::Range &range = prop.getRange();
-      setValue(prop,
-               tcrop<double>(prop.getValue() + add, range.first, range.second));
+    void addMinMaxSeparate(TIntPairProperty &prop, double min, double max) {
+      if (min == 0.0 && max == 0.0) return;
+      const TIntPairProperty::Range &range = prop.getRange();
+      TIntPairProperty::Value value = prop.getValue();
+      value.first += min;
+      value.second += max;
+      if (value.first > value.second) value.first = value.second;
+      value.first  = tcrop<double>(value.first, range.first, range.second);
+      value.second = tcrop<double>(value.second, range.first, range.second);
+      setValue(prop, value);
     }
 
   } locals = {this};
@@ -1264,9 +1290,10 @@ void FullColorEraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   case TMouseEvent::ALT_KEY: {
     // User wants to alter the maximum brush size
     const TPointD &diff = pos - m_mousePos;
-    double add          = (fabs(diff.x) > fabs(diff.y)) ? diff.x : diff.y;
+    double max          = diff.x / 2;
+    double min          = diff.y / 2;
 
-    locals.addValue(m_size, add);
+    locals.addMinMaxSeparate(m_size, min, max);
     break;
   }
 
@@ -1294,7 +1321,8 @@ void FullColorEraserTool::draw() {
     if (!Preferences::instance()->isCursorOutlineEnabled()) return;
 
     glColor3d(1.0, 0.0, 0.0);
-    tglDrawCircle(m_brushPos, (m_size.getValue() + 1) * 0.5);
+    tglDrawCircle(m_brushPos, (m_size.getValue().first + 1) * 0.5);
+    tglDrawCircle(m_brushPos, (m_size.getValue().second + 1) * 0.5);
   } else if (m_eraseType.getValue() == RECTERASE) {
     TPixel color = ToonzCheck::instance()->getChecks() & ToonzCheck::eBlackBg
                        ? TPixel32::White
@@ -1339,14 +1367,17 @@ void FullColorEraserTool::draw() {
 //----------------------------------------------------------------------------------------------------------
 
 bool FullColorEraserTool::onPropertyChanged(std::string propertyName) {
-  FullcolorEraseSize     = m_size.getValue();
-  FullcolorEraseHardness = m_hardness.getValue();
-  FullcolorEraserOpacity = m_opacity.getValue();
-  FullcolorEraserType    = ::to_string(m_eraseType.getValue());
-  FullcolorEraserInvert  = (int)m_invertOption.getValue();
-  FullcolorEraserRange   = (int)m_multi.getValue();
+  FullcolorEraseMinSize   = m_size.getValue().first;
+  FullcolorEraseSize      = m_size.getValue().second;
+  FullcolorEraseHardness  = m_hardness.getValue();
+  FullcolorEraserOpacity  = m_opacity.getValue();
+  FullcolorEraserType     = ::to_string(m_eraseType.getValue());
+  FullcolorEraserPressure = (int)m_pressure.getValue();
+  FullcolorEraserInvert   = (int)m_invertOption.getValue();
+  FullcolorEraserRange    = (int)m_multi.getValue();
   if (propertyName == "Hardness:" || propertyName == "Size:") {
-    m_brushPad = getBrushPad(m_size.getValue(), m_hardness.getValue() * 0.01);
+    m_brushPad =
+        getBrushPad(m_size.getValue().second, m_hardness.getValue() * 0.01);
     TRectD rect(
         m_brushPos - TPointD(FullcolorEraseSize + 2, FullcolorEraseSize + 2),
         m_brushPos + TPointD(FullcolorEraseSize + 2, FullcolorEraseSize + 2));

--- a/toonz/sources/tnztools/rastererasertool.cpp
+++ b/toonz/sources/tnztools/rastererasertool.cpp
@@ -63,6 +63,7 @@ using namespace ToolUtils;
 #define FREEHANDERASE L"Freehand"
 #define POLYLINEERASE L"Polyline"
 
+TEnv::DoubleVar EraseMinSize("InknpaintEraseMinSize", 1);
 TEnv::DoubleVar EraseSize("InknpaintEraseSize", 10);
 TEnv::StringVar EraseType("InknpaintEraseType", "Normal");
 TEnv::IntVar EraseSelective("InknpaintEraseSelective", 0);
@@ -71,8 +72,15 @@ TEnv::IntVar EraseRange("InknpaintEraseRange", 0);
 TEnv::StringVar EraseColorType("InknpaintEraseColorType", "Lines");
 TEnv::DoubleVar EraseHardness("EraseHardness", 100);
 TEnv::IntVar ErasePencil("InknpaintErasePencil", 0);
+TEnv::IntVar ErasePressure("InknpaintErasePressure", 1);
 
 namespace {
+
+int computeThickness(double pressure, const TIntPairProperty &property) {
+  const double curve = pressure * pressure * pressure;
+  const TIntPairProperty::Value size = property.getValue();
+  return tround(size.first + (size.second - size.first) * curve);
+}
 
 //==============================================================================
 //   Tools Undo Classes
@@ -508,7 +516,8 @@ private:
   TPropertyGroup m_prop;
 
   TEnumProperty m_eraseType;
-  TIntProperty m_toolSize;
+  TIntPairProperty m_toolSize;
+  TBoolProperty m_pressure;
   TDoubleProperty m_hardness;
   TBoolProperty m_invertOption;
   TBoolProperty m_currentStyle;
@@ -570,7 +579,7 @@ EraserTool inkPaintEraserTool("T_Eraser");
 
 EraserTool::EraserTool(std::string name)
     : TTool(name)
-    , m_toolSize("Size:", 1, 1000, 10, false)  // W_ToolOptions_EraserToolSize
+    , m_toolSize("Size:", 1, 1000, 1, 10, false)  // W_ToolOptions_EraserToolSize
     , m_hardness("Hardness:", 0, 100, 100)
     , m_eraseType("Type:")                // W_ToolOptions_Erasetype
     , m_colorType("Mode:")                // W_ToolOptions_InkOrPaint
@@ -592,7 +601,8 @@ EraserTool::EraserTool(std::string name)
     , m_isXsheetCell(false)
     , m_firstTime(true)
     , m_workingFrameId(TFrameId())
-    , m_isLeftButtonPressed(false) {
+    , m_isLeftButtonPressed(false)
+    , m_pressure("Pressure", true) {
   bind(TTool::ToonzImage);
 
   m_toolSize.setNonLinearSlider();
@@ -610,11 +620,13 @@ EraserTool::EraserTool(std::string name)
   m_colorType.addValue(ALL);
   m_prop.bind(m_colorType);
 
+  m_prop.bind(m_pressure);
   m_prop.bind(m_currentStyle);
   m_prop.bind(m_invertOption);
   m_prop.bind(m_multi);
   m_prop.bind(m_pencil);
 
+  m_pressure.setId("PressureSensitivity");
   m_currentStyle.setId("Selective");
   m_invertOption.setId("Invert");
   m_multi.setId("FrameRange");
@@ -627,6 +639,7 @@ EraserTool::EraserTool(std::string name)
 
 void EraserTool::updateTranslation() {
   m_toolSize.setQStringName(tr("Size:"));
+  m_pressure.setQStringName(tr("Pressure"));
   m_hardness.setQStringName(tr("Hardness:"));
 
   m_eraseType.setQStringName(tr("Type:"));
@@ -713,7 +726,10 @@ void EraserTool::draw() {
       glColor3d(0.5, 0.8, 0.8);
     else
       glColor3d(1.0, 0.0, 0.0);
-    drawEmptyCircle(tround(m_cleanerSize), m_brushPos,
+    drawEmptyCircle(tround(m_toolSize.getValue().first), m_brushPos,
+                    (m_pencil.getValue() || m_colorType.getValue() == AREAS),
+                    lx % 2 == 0, ly % 2 == 0);
+    drawEmptyCircle(tround(m_toolSize.getValue().second), m_brushPos,
                     (m_pencil.getValue() || m_colorType.getValue() == AREAS),
                     lx % 2 == 0, ly % 2 == 0);
   }
@@ -912,22 +928,25 @@ void EraserTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
     if (m_eraseType.getValue() == NORMALERASE) {
       TRasterCM32P raster = ti->getRaster();
       TPointD fixedPos    = fixMousePos(pos);
+      int maxThick        = m_toolSize.getValue().second;
+      int thickness       = (m_pressure.getValue() && e.isTablet())
+                                ? computeThickness(e.m_pressure, m_toolSize)
+                                : maxThick;
       TThickPoint intPos;
       /*-- When Areas type is selected, always use the same erasing method as
        * Pencil --*/
       if (m_pencil.getValue() || m_colorType.getValue() == AREAS)
         intPos = TThickPoint(fixedPos + convert(raster->getCenter()),
-                             m_toolSize.getValue());
+                             thickness);
       else
         intPos = TThickPoint(fixedPos + convert(raster->getCenter()),
-                             m_toolSize.getValue() - 1);
+                             thickness - 1);
       int currentStyle = 0;
       if (m_currentStyle.getValue())
         currentStyle = TTool::getApplication()->getCurrentLevelStyleIndex();
       m_tileSet   = new TTileSetCM32(raster->getSize());
       m_tileSaver = new TTileSaverCM32(raster, m_tileSet);
-      TPointD halfThick(m_toolSize.getValue() * 0.5,
-                        m_toolSize.getValue() * 0.5);
+      TPointD halfThick(maxThick * 0.5, maxThick * 0.5);
       invalidateRect = TRectD(fixedPos - halfThick, fixedPos + halfThick);
       if (m_hardness.getValue() == 100 || m_pencil.getValue() ||
           m_colorType.getValue() == AREAS) {
@@ -949,9 +968,9 @@ void EraserTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
         m_workRas   = TRaster32P(raster->getSize());
         m_workRas->clear();
         TPointD center = raster->getCenterD();
-        TThickPoint point(fixedPos + center, m_toolSize.getValue());
+        TThickPoint point(fixedPos + center, thickness);
         m_points.push_back(point);
-        m_bluredBrush = new BluredBrush(m_workRas, m_toolSize.getValue(),
+        m_bluredBrush = new BluredBrush(m_workRas, maxThick,
                                         m_brushPad, false);
 
         TRect bbox = m_bluredBrush->getBoundFromPoints(m_points);
@@ -1031,6 +1050,10 @@ void EraserTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
     }
     if (m_eraseType.getValue() == NORMALERASE) {
       TPointD fixedPos = fixMousePos(pos);
+      int maxThick     = m_toolSize.getValue().second;
+      int thickness    = (m_pressure.getValue() && e.isTablet())
+                             ? computeThickness(e.m_pressure, m_toolSize)
+                             : maxThick;
       if (m_normalEraser &&
           (m_hardness.getValue() == 100 || m_pencil.getValue() ||
            m_colorType.getValue() == AREAS)) {
@@ -1038,10 +1061,10 @@ void EraserTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
         TThickPoint intPos;
         if (m_pencil.getValue() || m_colorType.getValue() == AREAS)
           intPos = TThickPoint(pp + convert(ti->getRaster()->getCenter()),
-                               m_toolSize.getValue());
+                               thickness);
         else
           intPos = TThickPoint(pp + convert(ti->getRaster()->getCenter()),
-                               m_toolSize.getValue() - 1);
+                               thickness - 1);
 
         m_normalEraser->add(intPos);
         if (ti) {
@@ -1060,7 +1083,7 @@ void EraserTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
             points.push_back(brushPoints[m - 3]);
             points.push_back(brushPoints[m - 2]);
           }
-          invalidateRect = ToolUtils::getBounds(points, m_toolSize.getValue());
+          invalidateRect = ToolUtils::getBounds(points, maxThick);
         }
       } else {
         assert(m_workRas.getPointer() && m_backupRas.getPointer());
@@ -1068,7 +1091,6 @@ void EraserTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
         TThickPoint old = m_points.back();
         if (norm2(fixedPos - old) < 4) return;
 
-        int thickness = m_toolSize.getValue();
         TThickPoint point(fixedPos + rasCenter, thickness);
         TThickPoint mid((old + point) * 0.5, (point.thick + old.thick) * 0.5);
         m_points.push_back(mid);
@@ -1086,7 +1108,7 @@ void EraserTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
           std::vector<TThickPoint> points;
           points.push_back(pa);
           points.push_back(mid);
-          invalidateRect = ToolUtils::getBounds(points, thickness);
+          invalidateRect = ToolUtils::getBounds(points, maxThick);
           bbox           = m_bluredBrush->getBoundFromPoints(points);
           m_bluredBrush->addArc(pa, (mid + pa) * 0.5, mid, 1, 1);
         } else {
@@ -1094,7 +1116,7 @@ void EraserTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
           points.push_back(m_points[m - 4]);
           points.push_back(old);
           points.push_back(mid);
-          invalidateRect = ToolUtils::getBounds(points, thickness);
+          invalidateRect = ToolUtils::getBounds(points, maxThick);
           bbox           = m_bluredBrush->getBoundFromPoints(points);
           m_bluredBrush->addArc(m_points[m - 4], old, mid, 1, 1);
         }
@@ -1227,6 +1249,10 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
        * erasing --*/
       TFrameId frameId =
           m_workingFrameId.isEmptyFrame() ? getCurrentFid() : m_workingFrameId;
+      int maxThick  = m_toolSize.getValue().second;
+      int thickness = (m_pressure.getValue() && e.isTablet())
+                          ? computeThickness(e.m_pressure, m_toolSize)
+                          : maxThick;
 
       if (m_normalEraser &&
           (m_hardness.getValue() == 100 || m_pencil.getValue() ||
@@ -1243,7 +1269,7 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
       } else {
         if (m_points.size() != 1) {
           TPointD rasCenter = ti->getRaster()->getCenterD();
-          TThickPoint point(fixedPos + rasCenter, m_toolSize.getValue());
+          TThickPoint point(fixedPos + rasCenter, thickness);
           m_points.push_back(point);
           int m = m_points.size();
           std::vector<TThickPoint> points;
@@ -1257,7 +1283,7 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
                                       m_currentStyle.getValue(), currentStyle,
                                       m_colorType.getValue());
           TRectD invalidateRect =
-              ToolUtils::getBounds(points, m_toolSize.getValue());
+              ToolUtils::getBounds(points, maxThick);
           invalidate(invalidateRect.enlarge(2) - rasCenter);
         }
 
@@ -1267,7 +1293,7 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
         m_bluredBrush = nullptr;
         TUndoManager::manager()->add(new RasterBluredEraserUndo(
             m_tileSet, m_points, currentStyle, m_currentStyle.getValue(),
-            simLevel.getPointer(), frameId, m_toolSize.getValue(),
+            simLevel.getPointer(), frameId, maxThick,
             m_hardness.getValue() * 0.01, m_colorType.getValue()));
       }
       delete m_tileSaver;
@@ -1449,12 +1475,16 @@ bool EraserTool::onPropertyChanged(std::string propertyName) {
   }
 
   else if (propertyName == m_toolSize.getName()) {
-    EraseSize     = m_toolSize.getValue();
-    m_cleanerSize = m_toolSize.getValue();
+    EraseMinSize  = m_toolSize.getValue().first;
+    EraseSize     = m_toolSize.getValue().second;
+    m_cleanerSize = m_toolSize.getValue().second;
 
-    m_brushPad = ToolUtils::getBrushPad(m_toolSize.getValue(),
+    m_brushPad = ToolUtils::getBrushPad(m_toolSize.getValue().second,
                                         m_hardness.getValue() * 0.01);
   }
+
+  else if (propertyName == m_pressure.getName())
+    ErasePressure = m_pressure.getValue();
 
   else if (propertyName == m_invertOption.getName())
     EraseInvert = m_invertOption.getValue();
@@ -1479,13 +1509,13 @@ bool EraserTool::onPropertyChanged(std::string propertyName) {
 
   else if (propertyName == m_hardness.getName()) {
     EraseHardness = m_hardness.getValue();
-    m_brushPad    = ToolUtils::getBrushPad(m_toolSize.getValue(),
+    m_brushPad    = ToolUtils::getBrushPad(m_toolSize.getValue().second,
                                            m_hardness.getValue() * 0.01);
   }
 
   if (propertyName == m_hardness.getName() ||
       propertyName == m_toolSize.getName()) {
-    m_brushPad = ToolUtils::getBrushPad(m_toolSize.getValue(),
+    m_brushPad = ToolUtils::getBrushPad(m_toolSize.getValue().second,
                                         m_hardness.getValue() * 0.01);
     TRectD rect(m_brushPos - TPointD(EraseSize + 2, EraseSize + 2),
                 m_brushPos + TPointD(EraseSize + 2, EraseSize + 2));
@@ -1508,17 +1538,24 @@ void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   struct Locals {
     EraserTool *m_this;
 
-    void setValue(TIntProperty &prop, int value) {
+    void setValue(TIntPairProperty &prop,
+                  const TIntPairProperty::Value &value) {
       prop.setValue(value);
 
       m_this->onPropertyChanged(prop.getName());
       TTool::getApplication()->getCurrentTool()->notifyToolChanged();
     }
 
-    void addValue(TIntProperty &prop, double add) {
-      const TIntProperty::Range &range = prop.getRange();
-      setValue(prop,
-               tcrop<double>(prop.getValue() + add, range.first, range.second));
+    void addMinMaxSeparate(TIntPairProperty &prop, double min, double max) {
+      if (min == 0.0 && max == 0.0) return;
+      const TIntPairProperty::Range &range = prop.getRange();
+      TIntPairProperty::Value value = prop.getValue();
+      value.first += min;
+      value.second += max;
+      if (value.first > value.second) value.first = value.second;
+      value.first  = tcrop<double>(value.first, range.first, range.second);
+      value.second = tcrop<double>(value.second, range.first, range.second);
+      setValue(prop, value);
     }
 
   } locals = {this};
@@ -1527,9 +1564,10 @@ void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   case TMouseEvent::ALT_KEY: {
     // User wants to alter the maximum brush size
     const TPointD &diff = pos - m_mousePos;
-    double add          = (fabs(diff.x) > fabs(diff.y)) ? diff.x : diff.y;
+    double max          = diff.x / 2;
+    double min          = diff.y / 2;
 
-    locals.addValue(m_toolSize, add);
+    locals.addMinMaxSeparate(m_toolSize, min, max);
     break;
   }
 
@@ -1548,8 +1586,9 @@ void EraserTool::onEnter() {
   TToonzImageP ti(getImage(false));
   if (!ti) return;
   if (m_firstTime) {
-    m_toolSize.setValue(EraseSize);
+    m_toolSize.setValue(TIntPairProperty::Value(EraseMinSize, EraseSize));
     m_eraseType.setValue(::to_wstring(EraseType.getValue()));
+    m_pressure.setValue(ErasePressure ? 1 : 0);
     m_currentStyle.setValue(EraseSelective ? 1 : 0);
     m_invertOption.setValue(EraseInvert ? 1 : 0);
     m_colorType.setValue(::to_wstring(EraseColorType.getValue()));
@@ -1558,7 +1597,7 @@ void EraserTool::onEnter() {
     m_pencil.setValue(ErasePencil);
     m_firstTime = false;
   }
-  double x = m_toolSize.getValue();
+  double x = m_toolSize.getValue().second;
 
   double minRange = 1;
   double maxRange = 100;
@@ -1570,7 +1609,7 @@ void EraserTool::onEnter() {
       (x - minRange) / (maxRange - minRange) * (maxSize - minSize) + minSize;
 
   //  getApplication()->editImage();
-  m_cleanerSize           = m_toolSize.getValue();
+  m_cleanerSize           = m_toolSize.getValue().second;
   TTool::Application *app = TTool::getApplication();
   m_level                 = app->getCurrentLevel()->getLevel()
                                 ? app->getCurrentLevel()->getSimpleLevel()
@@ -1595,7 +1634,7 @@ void EraserTool::onActivate() {
     m_polyline.clear();
 
   onEnter();
-  m_brushPad = ToolUtils::getBrushPad(m_toolSize.getValue(),
+  m_brushPad = ToolUtils::getBrushPad(m_toolSize.getValue().second,
                                       m_hardness.getValue() * 0.01);
 }
 
@@ -1722,7 +1761,7 @@ void EraserTool::storeUndoAndRefresh() {
             ->getLevel()
             ->getSimpleLevel(),
         m_workingFrameId.isEmptyFrame() ? getCurrentFid() : m_workingFrameId,
-        m_toolSize.getValue(), m_hardness.getValue() * 0.01,
+        m_toolSize.getValue().second, m_hardness.getValue() * 0.01,
         m_colorType.getValue()));
   }
   if (m_tileSaver) {

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -2116,6 +2116,7 @@ EraserToolOptionsBox::EraserToolOptionsBox(QWidget *parent, TTool *tool,
   if (m_hardnessField)
     m_hardnessLabel = m_labels.value(m_hardnessField->propertyName());
   m_colorMode  = dynamic_cast<ToolOptionCombo *>(m_controls.value("Mode:"));
+  m_pressure = dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Pressure"));
   m_invertMode = dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Invert"));
   m_multiFrameMode =
       dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Frame Range"));
@@ -2142,6 +2143,7 @@ EraserToolOptionsBox::EraserToolOptionsBox(QWidget *parent, TTool *tool,
   if (m_toolType && m_toolType->getProperty()->getValue() == L"Normal") {
     m_invertMode->setEnabled(false);
     m_multiFrameMode->setEnabled(false);
+    if (m_pressure) m_pressure->setEnabled(true);
   }
 
   if (m_colorMode && m_colorMode->getProperty()->getValue() == L"Areas") {
@@ -2176,6 +2178,7 @@ void EraserToolOptionsBox::onToolTypeChanged(int index) {
   bool value                        = range[index] != L"Normal";
   m_invertMode->setEnabled(value);
   m_multiFrameMode->setEnabled(value);
+  if (m_pressure) m_pressure->setEnabled(!value);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/tnztools/vectorerasertool.cpp
+++ b/toonz/sources/tnztools/vectorerasertool.cpp
@@ -38,6 +38,7 @@
 
 using namespace ToolUtils;
 
+TEnv::DoubleVar EraseVectorMinSize("InknpaintEraseVectorMinSize", 1);
 TEnv::DoubleVar EraseVectorSize("InknpaintEraseVectorSize", 10);
 TEnv::StringVar EraseVectorType("InknpaintEraseVectorType", "Normal");
 TEnv::StringVar EraseVectorInterpolation("InknpaintEraseVectorInterpolation",
@@ -45,12 +46,21 @@ TEnv::StringVar EraseVectorInterpolation("InknpaintEraseVectorInterpolation",
 TEnv::IntVar EraseVectorSelective("InknpaintEraseVectorSelective", 0);
 TEnv::IntVar EraseVectorInvert("InknpaintEraseVectorInvert", 0);
 TEnv::IntVar EraseVectorRange("InknpaintEraseVectorRange", 0);
+TEnv::IntVar EraseVectorPressure("InknpaintEraseVectorPressure", 1);
 
 //=============================================================================
 // Eraser Tool
 //=============================================================================
 
 namespace {
+
+double computeThickness(double pressure, const TDoublePairProperty &property) {
+  double t      = pressure * pressure * pressure;
+  double thick0 = property.getValue().first;
+  double thick1 = property.getValue().second;
+  if (thick1 < 0.0001) thick0 = thick1 = 0.0;
+  return thick0 + (thick1 - thick0) * t;
+}
 
 #define NORMAL_ERASE L"Normal"
 #define RECT_ERASE L"Rectangular"
@@ -267,6 +277,8 @@ public:
 
   void draw() override;
 
+  void applyPressure(double pressure, bool isTablet);
+
   void startErase(TVectorImageP vi, const TPointD &pos);
   void erase(TVectorImageP vi, const TPointD &pos);
   void erase(TVectorImageP vi, TRectD &rect);
@@ -299,7 +311,8 @@ private:
 
   TEnumProperty m_eraseType;
   TEnumProperty m_interpolation;
-  TDoubleProperty m_toolSize;
+  TDoublePairProperty m_toolSize;
+  TBoolProperty m_pressure;
   TBoolProperty m_selective;
   TBoolProperty m_invertOption;
   TBoolProperty m_multi;
@@ -372,7 +385,7 @@ EraserTool::EraserTool()
     : TTool("T_Eraser")
     , m_eraseType("Type:")  // "W_ToolOptions_Erasetype"
     , m_interpolation("interpolation:")
-    , m_toolSize("Size:", 1, 1000, 10)  // "W_ToolOptions_EraserToolSize"
+    , m_toolSize("Size:", 1, 1000, 1, 10)  // "W_ToolOptions_EraserToolSize"
     , m_selective("Selective", false)   // "W_ToolOptions_Selective"
     , m_invertOption("Invert", false)   // "W_ToolOptions_Invert"
     , m_multi("Frame Range", false)     // "W_ToolOptions_FrameRange"
@@ -383,7 +396,8 @@ EraserTool::EraserTool()
     , m_firstStroke(nullptr)
     , m_thick(5)
     , m_active(false)
-    , m_firstTime(true) {
+    , m_firstTime(true)
+    , m_pressure("Pressure", true) {
   bind(TTool::VectorImage);
 
   m_toolSize.setNonLinearSlider();
@@ -395,6 +409,7 @@ EraserTool::EraserTool()
   m_eraseType.addValue(FREEHAND_ERASE);
   m_eraseType.addValue(POLYLINE_ERASE);
   m_eraseType.addValue(SEGMENT_ERASE);
+  m_prop.bind(m_pressure);
   m_prop.bind(m_selective);
   m_prop.bind(m_invertOption);
   m_prop.bind(m_multi);
@@ -404,6 +419,7 @@ EraserTool::EraserTool()
   m_interpolation.addValue(EASE_OUT_INTERPOLATION);
   m_interpolation.addValue(EASE_IN_OUT_INTERPOLATION);
 
+  m_pressure.setId("PressureSensitivity");
   m_selective.setId("Selective");
   m_invertOption.setId("Invert");
   m_multi.setId("FrameRange");
@@ -435,6 +451,7 @@ EraserTool::~EraserTool() {
 
 void EraserTool::updateTranslation() {
   m_toolSize.setQStringName(tr("Size:"));
+  m_pressure.setQStringName(tr("Pressure"));
   m_selective.setQStringName(tr("Selective"));
   m_invertOption.setQStringName(tr("Invert"));
   m_multi.setQStringName(tr("Frame Range"));
@@ -477,7 +494,20 @@ void EraserTool::draw() {
       if (!Preferences::instance()->isCursorOutlineEnabled()) return;
 
       tglColor(TPixel32(255, 0, 255));
-      tglDrawCircle(m_brushPos, m_pointSize);
+      const double minRange = 1;
+      const double maxRange = 100;
+      const double minSize  = 2;
+      const double maxSize  = 100;
+      const double min = ((m_toolSize.getValue().first - minRange) /
+                              (maxRange - minRange) * (maxSize - minSize) +
+                          minSize) *
+                         0.5;
+      const double max = ((m_toolSize.getValue().second - minRange) /
+                              (maxRange - minRange) * (maxSize - minSize) +
+                          minSize) *
+                         0.5;
+      tglDrawCircle(m_brushPos, min);
+      tglDrawCircle(m_brushPos, max);
     }
     if ((m_eraseType.getValue() == FREEHAND_ERASE ||
          m_eraseType.getValue() == POLYLINE_ERASE ||
@@ -534,6 +564,23 @@ void EraserTool::resetMulti() {
     delete m_firstStroke;
     m_firstStroke = nullptr;
   }
+}
+
+//-----------------------------------------------------------------------------
+
+void EraserTool::applyPressure(double pressure, bool isTablet) {
+  const double maxThick = m_toolSize.getValue().second;
+  const double thickness = (m_pressure.getValue() && isTablet)
+                               ? computeThickness(pressure, m_toolSize)
+                               : maxThick;
+  const double minRange = 1;
+  const double maxRange = 100;
+  const double minSize  = 2;
+  const double maxSize  = 100;
+  m_pointSize = ((thickness - minRange) / (maxRange - minRange) *
+                     (maxSize - minSize) +
+                 minSize) *
+                0.5;
 }
 
 //-----------------------------------------------------------------------------
@@ -854,6 +901,7 @@ void EraserTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
   TImageP image(getImage(true));
   m_activeImage = image;
   if (m_eraseType.getValue() == NORMAL_ERASE) {
+    applyPressure(e.m_pressure, e.isTablet());
     if (TVectorImageP vi = image) startErase(vi, pos);
   } else if (m_eraseType.getValue() == RECT_ERASE) {
     m_selectingRect.x0 = pos.x;
@@ -884,6 +932,7 @@ void EraserTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
     return;
   } else if (m_eraseType.getValue() == NORMAL_ERASE) {
     if (!m_undo) leftButtonDown(pos, e);
+    applyPressure(e.m_pressure, e.isTablet());
     if (TVectorImageP vi = image) erase(vi, pos);
   } else if (m_eraseType.getValue() == FREEHAND_ERASE ||
              m_eraseType.getValue() == SEGMENT_ERASE) {
@@ -1000,6 +1049,7 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
   if (!vi || !application) return;
   if (m_eraseType.getValue() == NORMAL_ERASE) {
     if (!m_undo) leftButtonDown(pos, e);
+    applyPressure(e.m_pressure, e.isTablet());
     stopErase(vi);
   } else if (m_eraseType.getValue() == RECT_ERASE) {
     if (m_selectingRect.x0 > m_selectingRect.x1)
@@ -1104,16 +1154,24 @@ void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   struct Locals {
     EraserTool *m_this;
 
-    void setValue(TDoubleProperty &prop, double value) {
+    void setValue(TDoublePairProperty &prop,
+                  const TDoublePairProperty::Value &value) {
       prop.setValue(value);
 
       m_this->onPropertyChanged(prop.getName());
       TTool::getApplication()->getCurrentTool()->notifyToolChanged();
     }
 
-    void addValue(TDoubleProperty &prop, double add) {
-      const TDoubleProperty::Range &range = prop.getRange();
-      setValue(prop, tcrop(prop.getValue() + add, range.first, range.second));
+    void addMinMaxSeparate(TDoublePairProperty &prop, double min, double max) {
+      if (min == 0.0 && max == 0.0) return;
+      const TDoublePairProperty::Range &range = prop.getRange();
+      TDoublePairProperty::Value value = prop.getValue();
+      value.first += min;
+      value.second += max;
+      if (value.first > value.second) value.first = value.second;
+      value.first  = tcrop<double>(value.first, range.first, range.second);
+      value.second = tcrop<double>(value.second, range.first, range.second);
+      setValue(prop, value);
     }
 
   } locals = {this};
@@ -1122,9 +1180,10 @@ void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
   case TMouseEvent::ALT_KEY: {
     // User wants to alter the maximum brush size
     const TPointD &diff = pos - m_mousePos;
-    double add          = (fabs(diff.x) > fabs(diff.y)) ? diff.x : diff.y;
+    double max          = diff.x / 2;
+    double min          = diff.y / 2;
 
-    locals.addValue(m_toolSize, add);
+    locals.addMinMaxSeparate(m_toolSize, min, max);
     break;
   }
 
@@ -1142,12 +1201,14 @@ void EraserTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
 bool EraserTool::onPropertyChanged(std::string propertyName) {
   EraseVectorType          = ::to_string(m_eraseType.getValue());
   EraseVectorInterpolation = ::to_string(m_interpolation.getValue());
-  EraseVectorSize          = m_toolSize.getValue();
+  EraseVectorMinSize       = m_toolSize.getValue().first;
+  EraseVectorSize          = m_toolSize.getValue().second;
+  EraseVectorPressure      = m_pressure.getValue();
   EraseVectorSelective     = m_selective.getValue();
   EraseVectorInvert        = m_invertOption.getValue();
   EraseVectorRange         = m_multi.getValue();
 
-  double x = m_toolSize.getValue();
+  double x = m_toolSize.getValue().second;
 
   double minRange = 1;
   double maxRange = 100;
@@ -1167,16 +1228,18 @@ bool EraserTool::onPropertyChanged(std::string propertyName) {
 
 void EraserTool::onEnter() {
   if (m_firstTime) {
-    m_toolSize.setValue(EraseVectorSize);
+    m_toolSize.setValue(
+        TDoublePairProperty::Value(EraseVectorMinSize, EraseVectorSize));
     m_eraseType.setValue(::to_wstring(EraseVectorType.getValue()));
     m_interpolation.setValue(::to_wstring(EraseVectorInterpolation.getValue()));
+    m_pressure.setValue(EraseVectorPressure ? 1 : 0);
     m_selective.setValue(EraseVectorSelective ? 1 : 0);
     m_invertOption.setValue(EraseVectorInvert ? 1 : 0);
     m_multi.setValue(EraseVectorRange ? 1 : 0);
     m_firstTime = false;
   }
 
-  double x = m_toolSize.getValue();
+  double x = m_toolSize.getValue().second;
 
   double minRange = 1;
   double maxRange = 100;


### PR DESCRIPTION
Adds pressure-sensitive eraser size controls for Smart Raster, full-color raster, and vector levels.

The Size control now stores minimum and maximum values. Tablet pressure maps cubically across that range for normal erasing; the new Pressure option enables or disables that mapping. The maximum size remains the brush allocation, invalidation, and undo bound.

Also adds the dual-ring cursor preview and enables Pressure only for Normal erase mode.

Tests:
- Direct compilation: rastererasertool.cpp
- Direct compilation: fullcolorerasertool.cpp
- Direct compilation: vectorerasertool.cpp
- Direct compilation: tooloptions.cpp
- git diff --check