### PR TITLE
[T2D-114] Add full-color MyPaint brush smoothing

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -51,6 +51,7 @@
 
 TEnv::IntVar FullcolorBrushMinSize("FullcolorBrushMinSize", 1);
 TEnv::IntVar FullcolorBrushMaxSize("FullcolorBrushMaxSize", 5);
+TEnv::IntVar FullcolorBrushSmooth("FullcolorBrushSmooth", 0);
 TEnv::IntVar FullcolorPressureSensitivity("FullcolorPressureSensitivity", 1);
 TEnv::DoubleVar FullcolorBrushHardness("FullcolorBrushHardness", 100);
 TEnv::DoubleVar FullcolorMinOpacity("FullcolorMinOpacity", 100);
@@ -120,6 +121,7 @@ public:
 FullColorBrushTool::FullColorBrushTool(std::string name)
     : TTool(name)
     , m_thickness("Size", 1, 1000, 1, 5, false)
+    , m_smooth("Smooth:", 0, 500, 0)
     , m_pressure("Pressure", true)
     , m_opacity("Opacity", 0, 100, 100, 100, true)
     , m_hardness("Hardness:", 0, 100, 100)
@@ -140,8 +142,10 @@ FullColorBrushTool::FullColorBrushTool(std::string name)
     , m_started(false) {
   bind(TTool::RasterImage | TTool::EmptyTarget);
   m_thickness.setNonLinearSlider();
+  m_smooth.setNonLinearSlider();
 
   m_prop.bind(m_thickness);
+  m_prop.bind(m_smooth);
   m_prop.bind(m_hardness);
   m_prop.bind(m_opacity);
   m_prop.bind(m_modifierSize);
@@ -160,6 +164,8 @@ FullColorBrushTool::FullColorBrushTool(std::string name)
   m_modifierTangents     = new TModifierTangents();
   m_modifierAssistants   = new TModifierAssistants();
   m_modifierSegmentation = new TModifierSegmentation();
+  m_modifierSmoothSegmentation = new TModifierSegmentation(TPointD(1, 1), 3);
+  for (int i = 0; i < 3; ++i) m_modifierSmooth[i] = new TModifierSmooth();
 
   m_inputmanager.addModifier(
       TInputModifierP(m_modifierAssistants.getPointer()));
@@ -169,6 +175,7 @@ FullColorBrushTool::FullColorBrushTool(std::string name)
   m_modifierEraser.setId("RasterEraser");
   m_modifierLockAlpha.setId("LockAlpha");
   m_pressure.setId("PressureSensitivity");
+  m_smooth.setId("Smooth");
 }
 
 //-------------------------------------------------------------------------------------------------------
@@ -209,6 +216,7 @@ void FullColorBrushTool::onColorStyleChanged() {
 
 void FullColorBrushTool::updateTranslation() {
   m_thickness.setQStringName(tr("Size"));
+  m_smooth.setQStringName(tr("Smooth:"));
   m_pressure.setQStringName(tr("Pressure"));
   m_opacity.setQStringName(tr("Opacity"));
   m_hardness.setQStringName(tr("Hardness:"));
@@ -322,6 +330,7 @@ bool FullColorBrushTool::askWrite(const TRect &rect) {
 //--------------------------------------------------------------------------------------------------
 
 void FullColorBrushTool::updateModifiers() {
+  const int smoothRadius          = m_smooth.getValue();
   m_modifierAssistants->magnetism = m_assistants.getValue() ? 1 : 0;
   m_inputmanager.drawPreview      = false; //!m_modifierAssistants->drawOnly;
 
@@ -331,6 +340,15 @@ void FullColorBrushTool::updateModifiers() {
   
   m_inputmanager.clearModifiers();
   m_inputmanager.addModifier(TInputModifierP(m_modifierTangents.getPointer()));
+  if (smoothRadius > 0) {
+    m_inputmanager.addModifier(
+        TInputModifierP(m_modifierSmoothSegmentation.getPointer()));
+    for (int i = 0; i < 3; ++i) {
+      m_modifierSmooth[i]->radius = smoothRadius;
+      m_inputmanager.addModifier(
+          TInputModifierP(m_modifierSmooth[i].getPointer()));
+    }
+  }
   m_inputmanager.addModifier(
       TInputModifierP(m_modifierAssistants.getPointer()));
 #ifndef NDEBUG
@@ -701,6 +719,7 @@ bool FullColorBrushTool::onPropertyChanged(std::string propertyName) {
 
   FullcolorBrushMinSize        = m_thickness.getValue().first;
   FullcolorBrushMaxSize        = m_thickness.getValue().second;
+  FullcolorBrushSmooth         = m_smooth.getValue();
   FullcolorPressureSensitivity = m_pressure.getValue();
   FullcolorBrushHardness       = m_hardness.getValue();
   FullcolorMinOpacity          = m_opacity.getValue().first;
@@ -757,6 +776,7 @@ void FullColorBrushTool::loadPreset() {
   {
     m_thickness.setValue(TIntPairProperty::Value(std::max((int)preset.m_min, 1),
                                                  (int)preset.m_max));
+    m_smooth.setValue(preset.m_smooth, true);
     m_hardness.setValue(preset.m_hardness, true);
     m_opacity.setValue(
         TDoublePairProperty::Value(preset.m_opacityMin, preset.m_opacityMax));
@@ -812,6 +832,7 @@ void FullColorBrushTool::addPreset(QString name) {
 
   preset.m_min               = m_thickness.getValue().first;
   preset.m_max               = m_thickness.getValue().second;
+  preset.m_smooth            = m_smooth.getValue();
   preset.m_hardness          = m_hardness.getValue();
   preset.m_opacityMin        = m_opacity.getValue().first;
   preset.m_opacityMax        = m_opacity.getValue().second;
@@ -867,6 +888,7 @@ void FullColorBrushTool::removePreset() {
 void FullColorBrushTool::loadLastBrush() {
   m_thickness.setValue(
       TIntPairProperty::Value(FullcolorBrushMinSize, FullcolorBrushMaxSize));
+  m_smooth.setValue(FullcolorBrushSmooth);
   m_pressure.setValue(FullcolorPressureSensitivity ? 1 : 0);
   m_opacity.setValue(
       TDoublePairProperty::Value(FullcolorMinOpacity, FullcolorMaxOpacity));

--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -13,6 +13,7 @@
 #include <tools/modifiers/modifiertangents.h>
 #include <tools/modifiers/modifierassistants.h>
 #include <tools/modifiers/modifiersegmentation.h>
+#include <tools/modifiers/modifiersmooth.h>
 
 #include "toonzrasterbrushtool.h"
 #include "mypainttoonzbrush.h"
@@ -129,11 +130,14 @@ protected:
   TSmartPointerT<TModifierTangents> m_modifierTangents;
   TSmartPointerT<TModifierAssistants> m_modifierAssistants;
   TSmartPointerT<TModifierSegmentation> m_modifierSegmentation;
+  TSmartPointerT<TModifierSegmentation> m_modifierSmoothSegmentation;
+  TSmartPointerT<TModifierSmooth> m_modifierSmooth[3];
   TInputModifier::List m_modifierReplicate;
 
   TPropertyGroup m_prop;
 
   TIntPairProperty m_thickness;
+  TIntProperty m_smooth;
   TBoolProperty m_pressure;
   TDoublePairProperty m_opacity;
   TDoubleProperty m_hardness;


### PR DESCRIPTION
Adds the existing `Smooth:` input-modifier pipeline to the full-color raster brush, including MyPaint styles.

The setting is retained in brush presets and last-used tool settings. Smart Raster already has the same current smoothing pipeline, so this PR applies it only to the missing full-color target.

Tests:
- Direct compilation: fullcolorbrushtool.cpp
- git diff --check