### PR TITLE
[T2D-115] Add control-point curve commands

### DIFF
--- a/toonz/sources/include/toonzqt/selectioncommandids.h
+++ b/toonz/sources/include/toonzqt/selectioncommandids.h
@@ -43,4 +43,7 @@
 #define MI_PasteNumbers "MI_PasteNumbers"
 #define MI_PasteCellContent "MI_PasteCellContent"
 
+#define MI_SetLinearControlPoint "MI_SetLinearControlPoint"
+#define MI_SetNonLinearControlPoint "MI_SetNonLinearControlPoint"
+
 #endif

--- a/toonz/sources/tnztools/controlpointselection.cpp
+++ b/toonz/sources/tnztools/controlpointselection.cpp
@@ -8,6 +8,8 @@
 #include "tools/toolhandle.h"
 #include "tools/toolutils.h"
 
+#include "toonzqt/selectioncommandids.h"
+
 #include "toonz/tobjecthandle.h"
 #include "toonz/txshlevelhandle.h"
 #include "toonz/tstageobject.h"
@@ -1095,13 +1097,11 @@ void ControlPointSelection::addMenuItems(QMenu *menu) {
        m_controlPointEditorStroke->getControlPointCount() <= 1))
     return;
 
-  QAction *linear   = menu->addAction(tr("Set Linear Control Point"));
-  QAction *unlinear = menu->addAction(tr("Set Nonlinear Control Point"));
+  menu->addAction(
+      CommandManager::instance()->getAction(MI_SetLinearControlPoint));
+  menu->addAction(
+      CommandManager::instance()->getAction(MI_SetNonLinearControlPoint));
   menu->addSeparator();
-
-  connect(linear, &QAction::triggered, this, &ControlPointSelection::setLinear);
-  connect(unlinear, &QAction::triggered, this,
-          &ControlPointSelection::setUnlinear);
 }
 
 //-----------------------------------------------------------------------------
@@ -1268,5 +1268,9 @@ void ControlPointSelection::deleteControlPoints() {
 //-----------------------------------------------------------------------------
 
 void ControlPointSelection::enableCommands() {
-  enableCommand(this, "MI_Clear", &ControlPointSelection::deleteControlPoints);
+  enableCommand(this, MI_Clear, &ControlPointSelection::deleteControlPoints);
+  enableCommand(this, MI_SetLinearControlPoint,
+                &ControlPointSelection::setLinear);
+  enableCommand(this, MI_SetNonLinearControlPoint,
+                &ControlPointSelection::setUnlinear);
 }

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2407,6 +2407,10 @@ void MainWindow::defineActions() {
   createRightClickMenuAction(MI_EraseUnusedStyles,
                              QT_TR_NOOP("&Delete Unused Styles"), "",
                              "delete_unused_styles");
+  createRightClickMenuAction(MI_SetLinearControlPoint,
+                             QT_TR_NOOP("&Set Linear Control Point"), "");
+  createRightClickMenuAction(MI_SetNonLinearControlPoint,
+                             QT_TR_NOOP("&Set Nonlinear Control Point"), "");
 
   // Menu - View
 


### PR DESCRIPTION
Registers the existing Set Linear Control Point and Set Nonlinear Control Point operations as shared commands.

The control-point context menu now uses those shared actions, so both operations can be assigned shortcuts and invoked through the command manager while preserving existing selection and undo behavior.

Tests:
- Direct compilation: controlpointselection.cpp
- Direct compilation: mainwindow.cpp
- git diff --check