### PR TITLE
[T2D-117] Add vector brush mode shortcuts

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2841,6 +2841,17 @@ void MainWindow::defineActions() {
   createAction(MI_SelectionPolyline, QT_TR_NOOP("Selection Tool - Polyline"),
                "", ToolCommandType, "selection_polyline");
 
+  /*-- Brush tool + option shortcuts --*/
+  createAction(MI_BrushAutoFillOn, QT_TR_NOOP("Brush Tool - Auto Fill On"),
+               "", ToolCommandType);
+  createAction(MI_BrushAutoFillOff,
+               QT_TR_NOOP("Brush Tool - Auto Close/Group/Fill Off"), "",
+               ToolCommandType);
+  createAction(MI_BrushAutoCloseOn, QT_TR_NOOP("Brush Tool - Auto Close On"),
+               "", ToolCommandType);
+  createAction(MI_BrushAutoGroupOn, QT_TR_NOOP("Brush Tool - Auto Group On"),
+               "", ToolCommandType);
+
   /*-- Geometric tool + shape switching shortcuts --*/
   createAction(MI_GeometricNextShape, QT_TR_NOOP("Geometric Tool - Next Shape"),
                "", ToolCommandType);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -437,6 +437,11 @@
 #define MI_PlasticBuildSkeleton "MI_PlasticBuildSkeleton"
 #define MI_PlasticAnimate "MI_PlasticAnimate"
 
+#define MI_BrushAutoFillOn "MI_BrushAutoFillOn"
+#define MI_BrushAutoFillOff "MI_BrushAutoFillOff"
+#define MI_BrushAutoCloseOn "MI_BrushAutoCloseOn"
+#define MI_BrushAutoGroupOn "MI_BrushAutoGroupOn"
+
 #define MI_DeactivateUpperColumns "MI_DeactivateUpperColumns"
 #define MI_CompareToSnapshot "MI_CompareToSnapshot"
 #define MI_PreviewFx "MI_PreviewFx"

--- a/toonz/sources/toonz/tooloptionsshortcutinvoker.cpp
+++ b/toonz/sources/toonz/tooloptionsshortcutinvoker.cpp
@@ -600,6 +600,16 @@ void ToolOptionsShortcutInvoker::initialize() {
   setCommandHandler(MI_PlasticAnimate, this,
                     &ToolOptionsShortcutInvoker::TogglePlasticAnimate);
 
+  /*-- Brush tool + option shortcuts --*/
+  setCommandHandler(MI_BrushAutoFillOff, this,
+                    &ToolOptionsShortcutInvoker::toggleBrushAutoFillOff);
+  setCommandHandler(MI_BrushAutoFillOn, this,
+                    &ToolOptionsShortcutInvoker::toggleBrushAutoFillOn);
+  setCommandHandler(MI_BrushAutoCloseOn, this,
+                    &ToolOptionsShortcutInvoker::toggleBrushAutoCloseOn);
+  setCommandHandler(MI_BrushAutoGroupOn, this,
+                    &ToolOptionsShortcutInvoker::toggleBrushAutoGroupOn);
+
   /*-- Edit Assistants tool + type switching shortcuts --*/
   setCommandHandler(MI_AssistantNextType, this,
                     &ToolOptionsShortcutInvoker::toggleAssistantNextType);
@@ -1271,4 +1281,41 @@ void ToolOptionsShortcutInvoker::TogglePlasticAnimate() {
   CommandManager::instance()
       ->getAction("A_ToolOption_SkeletonMode:Animate")
       ->trigger();
+}
+
+//-----------------------------------------------------------------------------
+/*-- Brush tool + option shortcuts --*/
+void ToolOptionsShortcutInvoker::toggleBrushAutoFillOff() {
+  CommandManager::instance()->getAction(T_Brush)->trigger();
+
+  QAction* action =
+      CommandManager::instance()->getAction("A_ToolOption_Autofill");
+  if (action->isChecked()) action->trigger();
+
+  action = CommandManager::instance()->getAction("A_ToolOption_AutoGroup");
+  if (action->isChecked()) action->trigger();
+
+  action = CommandManager::instance()->getAction("A_ToolOption_AutoClose");
+  if (action->isChecked()) action->trigger();
+}
+
+void ToolOptionsShortcutInvoker::toggleBrushAutoFillOn() {
+  CommandManager::instance()->getAction(T_Brush)->trigger();
+  QAction* action =
+      CommandManager::instance()->getAction("A_ToolOption_Autofill");
+  if (!action->isChecked()) action->trigger();
+}
+
+void ToolOptionsShortcutInvoker::toggleBrushAutoCloseOn() {
+  CommandManager::instance()->getAction(T_Brush)->trigger();
+  QAction* action =
+      CommandManager::instance()->getAction("A_ToolOption_AutoClose");
+  if (!action->isChecked()) action->trigger();
+}
+
+void ToolOptionsShortcutInvoker::toggleBrushAutoGroupOn() {
+  CommandManager::instance()->getAction(T_Brush)->trigger();
+  QAction* action =
+      CommandManager::instance()->getAction("A_ToolOption_AutoGroup");
+  if (!action->isChecked()) action->trigger();
 }

--- a/toonz/sources/toonz/tooloptionsshortcutinvoker.h
+++ b/toonz/sources/toonz/tooloptionsshortcutinvoker.h
@@ -204,6 +204,12 @@ protected slots:
   void togglePaintBrushLines();
   void togglePaintBrushLinesAndAreas();
 
+  /*-- Brush tool + option shortcuts --*/
+  void toggleBrushAutoFillOff();
+  void toggleBrushAutoFillOn();
+  void toggleBrushAutoCloseOn();
+  void toggleBrushAutoGroupOn();
+
   /*-- Fill tool + mode switching shortcuts --*/
   void toggleFillNextType();
   void toggleFillNormal();


### PR DESCRIPTION
Adds commands that activate the Brush tool and set its Auto Fill, Auto Close, and Auto Group options. The all-off command disables all three options.