### PR TITLE
[T2D-120] Convert single-image levels to sequences

### DIFF
--- a/toonz/sources/include/tfilepath.h
+++ b/toonz/sources/include/tfilepath.h
@@ -112,6 +112,10 @@ public:
 
     return (m_startSeqInd == '.' ? CUSTOM_PAD : UNDERSCORE_CUSTOM_PAD);
   }
+
+  void convertToSequence() {
+    if (isEmptyFrame() || isNoFrame()) m_frame = 0;
+  }
 };
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/include/toonz/txshsimplelevel.h
+++ b/toonz/sources/include/toonz/txshsimplelevel.h
@@ -27,6 +27,8 @@
 #include <boost/container/flat_set.hpp>
 #include <boost/container/flat_map.hpp>
 
+class TXsheet;
+
 #undef DVAPI
 #undef DVVAR
 #ifdef TOONZLIB_EXPORTS
@@ -288,6 +290,10 @@ public:
   void renumber(const std::vector<TFrameId> &fids);
 
   bool isFrameReadOnly(TFrameId fid);
+
+  bool isSingleFileLevel() const;
+  bool canConvertSingleFileToSequence() const;
+  void convertSingleFileToSequence(TXsheet *xsheet);
 
 public:
   // Static methods for auxiliary files management: hooks, tpl, etc.

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -137,7 +137,8 @@ FullColorBrushTool::FullColorBrushTool(std::string name)
     , m_notifier(0)
     , m_presetsLoaded(false)
     , m_firstTime(true)
-    , m_started(false) {
+    , m_started(false)
+    , m_active(false) {
   bind(TTool::RasterImage | TTool::EmptyTarget);
   m_thickness.setNonLinearSlider();
 
@@ -345,7 +346,8 @@ void FullColorBrushTool::updateModifiers() {
 
 bool FullColorBrushTool::preLeftButtonDown() {
   updateModifiers();
-  touchImage();
+  m_active = touchImage();
+  if (!m_active) return false;
 
   if (m_isFrameCreated) {
     setWorkAndBackupImages();
@@ -407,14 +409,17 @@ void FullColorBrushTool::handleMouseEvent(MouseEventType type,
 
 void FullColorBrushTool::leftButtonDown(const TPointD &pos,
                                         const TMouseEvent &e) {
+  if (!m_active) return;
   handleMouseEvent(ME_DOWN, pos, e);
 }
 void FullColorBrushTool::leftButtonDrag(const TPointD &pos,
                                         const TMouseEvent &e) {
+  if (!m_active) return;
   handleMouseEvent(ME_DRAG, pos, e);
 }
 void FullColorBrushTool::leftButtonUp(const TPointD &pos,
                                       const TMouseEvent &e) {
+  if (!m_active) return;
   handleMouseEvent(ME_UP, pos, e);
 }
 void FullColorBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {

--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -167,6 +167,7 @@ protected:
   bool m_firstTime;
 
   bool m_started;
+  bool m_active;
 
   bool m_propertyUpdating = false;
 };

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -11,6 +11,7 @@
 
 // TnzQt includes
 #include "toonzqt/icongenerator.h"
+#include "toonzqt/dvdialog.h"
 
 // TnzLib includes
 #include "toonzqt/menubarcommand.h"
@@ -48,6 +49,26 @@
 #include "tundo.h"
 
 #include "toonzvectorbrushtool.h"
+
+namespace {
+bool convertSingleFileLevel(TXshSimpleLevel *level, TXsheet *xsheet) {
+  if (!level || !level->isSingleFileLevel()) return true;
+  if (!level->canConvertSingleFileToSequence()) {
+    DVGui::error(QObject::tr("Cannot add frames to a Single Frame level."));
+    return false;
+  }
+
+  const int choice = DVGui::MsgBox(
+      QObject::tr("In order to create a new frame in this Single Frame level, "
+                  "it will need to be converted and saved as a new sequenced "
+                  "file level.\nWould you like to continue?"),
+      QObject::tr("Ok"), QObject::tr("Cancel"));
+  if (choice == 0 || choice == 2) return false;
+
+  level->convertSingleFileToSequence(xsheet);
+  return true;
+}
+}  // namespace
 
 //*****************************************************************************************
 //    Local namespace
@@ -381,6 +402,9 @@ TImage *TTool::touchImage() {
       // no drawing found
       if (sl->isSubsequence() || sl->isReadOnly() || !isAutoCreateEnabled)
         return 0;
+      if (!convertSingleFileLevel(
+              sl, m_application->getCurrentXsheet()->getXsheet()))
+        return 0;
 
       // create a new drawing
       img = sl->createEmptyFrame();
@@ -411,6 +435,12 @@ TImage *TTool::touchImage() {
   TXshSimpleLevel *sl = cell.getSimpleLevel();
 
   if (sl) {
+    const bool createsFrame =
+        (isCreateInHoldCellsEnabled && row > 0 &&
+         xsh->getCell(row - 1, col) == xsh->getCell(row, col)) ||
+        !sl->isFid(cell.getFrameId());
+    if (createsFrame && !convertSingleFileLevel(sl, xsh)) return 0;
+
     // current cell is not empty
     if (isCreateInHoldCellsEnabled && row > 0 &&
         xsh->getCell(row - 1, col) == xsh->getCell(row, col)) {
@@ -503,6 +533,8 @@ TImage *TTool::touchImage() {
     } else if (b <= r1) {
       sl = xsh->getCell(b, col).getSimpleLevel();
     }
+    if (!convertSingleFileLevel(sl, xsh)) return 0;
+
     if (sl && !sl->isSubsequence() && !sl->isReadOnly()) {
       // note: sl should be always !=0 (the column is not empty)
       // if - for some reason - it is == 0 or it is not editable,

--- a/toonz/sources/tnztools/typetool.cpp
+++ b/toonz/sources/tnztools/typetool.cpp
@@ -1205,7 +1205,9 @@ void TypeTool::mouseMove(const TPointD &pos, const TMouseEvent &) {
 bool TypeTool::preLeftButtonDown() {
   if (getViewer() && getViewer()->getGuidedStrokePickerMode()) return false;
 
-  if (m_validFonts && !m_active) touchImage();
+  m_active = false;
+  if (m_validFonts && !touchImage()) return false;
+  m_active = true;
   return true;
 }
 
@@ -1220,12 +1222,16 @@ void TypeTool::leftButtonDown(const TPointD &pos, const TMouseEvent &) {
   }
 
   if (!m_validFonts) return;
+  if (!m_active) return;
 
   TImageP img      = getImage(true);
   TVectorImageP vi = img;
   TToonzImageP ti  = img;
 
-  if (!vi && !ti) return;
+  if (!vi && !ti) {
+    m_active = false;
+    return;
+  }
 
   setSize(m_size.getValue());
 
@@ -1242,8 +1248,6 @@ void TypeTool::leftButtonDown(const TPointD &pos, const TMouseEvent &) {
 
   //  closeImeWindow();
   //  if(m_viewer) m_viewer->enableIme(true);
-  m_active = true;
-
   if (!m_string.empty()) {
     TPointD clickPoint =
         (TFontManager::instance()->hasVertical() && m_isVertical)

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -17,6 +17,7 @@
 #include "toonzqt/trepetitionguard.h"
 #include "toonzqt/gutil.h"
 #include "toonzqt/tselectionhandle.h"
+#include "toonzqt/dvdialog.h"
 
 // TnzLib includes
 #include "toonz/txshlevelhandle.h"
@@ -1145,6 +1146,25 @@ void FilmstripFrames::keyPressEvent(QKeyEvent *event) {
   std::vector<TFrameId> fids;
   level->getFids(fids);
   if (fids.empty()) return;
+
+  if (level->isSingleFileLevel() &&
+      (event->key() == Qt::Key_Down || event->key() == Qt::Key_Right)) {
+    if (!level->canConvertSingleFileToSequence()) {
+      DVGui::error(tr("Cannot add frames to a Single Frame level."));
+      return;
+    }
+
+    const int choice = DVGui::MsgBox(
+        tr("In order to create a new frame in this Single Frame level, it "
+           "will need to be converted and saved as a new sequenced file "
+           "level.\nWould you like to continue?"),
+        tr("Ok"), tr("Cancel"));
+    if (choice == 0 || choice == 2) return;
+
+    level->convertSingleFileToSequence(
+        TApp::instance()->getCurrentXsheet()->getXsheet());
+    level->getFids(fids);
+  }
 
   // If on a level frame pass the frame id after the last frame to allow
   // creating a new frame with the down arrow key

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -18,6 +18,8 @@
 #include "toonz/mypaintbrushstyle.h"
 #include "toonz/levelset.h"
 #include "toonz/tcamera.h"
+#include "toonz/txshcell.h"
+#include "toonz/txsheet.h"
 
 // TnzBase includes
 #include "tenv.h"
@@ -2366,4 +2368,50 @@ bool TXshSimpleLevel::isFrameReadOnly(TFrameId fid) {
     return false;
 
   return m_isReadOnly;
+}
+
+//-----------------------------------------------------------------------------
+
+bool TXshSimpleLevel::isSingleFileLevel() const {
+  return m_frames.size() == 1 &&
+         (m_frames.begin()->getNumber() == TFrameId::EMPTY_FRAME ||
+          m_frames.begin()->getNumber() == TFrameId::NO_FRAME);
+}
+
+//-----------------------------------------------------------------------------
+
+bool TXshSimpleLevel::canConvertSingleFileToSequence() const {
+  return m_type == OVL_XSHLEVEL && isSingleFileLevel() &&
+         !m_path.isUneditable();
+}
+
+//-----------------------------------------------------------------------------
+
+void TXshSimpleLevel::convertSingleFileToSequence(TXsheet *xsheet) {
+  if (!isSingleFileLevel()) return;
+
+  const TFrameId oldFid = *m_frames.begin();
+  TFrameId newFid       = oldFid;
+  TImageP image         = getFrame(oldFid, false);
+  if (!image) return;
+
+  eraseFrame(oldFid);
+  newFid.convertToSequence();
+  setFrame(newFid, image->cloneImage());
+  m_path = m_path.withFrame();
+
+  if (!xsheet) return;
+
+  const TXshCell replacement(this, newFid);
+  for (int column = 0; column < xsheet->getColumnCount(); ++column) {
+    int firstRow = 0;
+    int lastRow  = -1;
+    xsheet->getCellRange(column, firstRow, lastRow);
+    for (int row = firstRow; row <= lastRow; ++row) {
+      const TXshCell cell = xsheet->getCell(row, column);
+      if (!cell.isEmpty() && cell.m_level == this &&
+          cell.getFrameId() == oldFid)
+        xsheet->setCell(row, column, replacement);
+    }
+  }
 }


### PR DESCRIPTION
Prompts before creating another drawing from a single-image raster level, converts the level to a numbered sequence, and updates existing Xsheet references. Brush and Type tools stop cleanly when conversion is cancelled.