### PR TITLE
[T2D-127] Add clear onion skin markers command

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2654,6 +2654,8 @@ void MainWindow::defineActions() {
                RightClickMenuCommandType, "zero_thick_lines");
   createToggle(MI_CursorOutline, QT_TR_NOOP("Toggle Cursor Size Outline"), "",
                false, RightClickMenuCommandType);
+  createRightClickMenuAction(MI_ClearAllOnionSkinMarkers,
+                             QT_TR_NOOP("&Clear All Onion Skin Markers"), "");
   createRightClickMenuAction(MI_ToggleCurrentTimeIndicator,
                              QT_TR_NOOP("Toggle Current Time Indicator"), "");
   createRightClickMenuAction(MI_DuplicateFile, QT_TR_NOOP("Duplicate"), "",

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -242,6 +242,7 @@
 #define MI_FullScreenWindow "MI_FullScreenWindow"
 #define MI_SeeThroughWindow "MI_SeeThroughWindow"
 #define MI_OnionSkin "MI_OnionSkin"
+#define MI_ClearAllOnionSkinMarkers "MI_ClearAllOnionSkinMarkers"
 #define MI_ZeroThick "MI_ZeroThick"
 #define MI_CursorOutline "MI_CursorOutline"
 #define MI_ViewerIndicator "MI_ViewerIndicator"

--- a/toonz/sources/toonz/onionskinmaskgui.cpp
+++ b/toonz/sources/toonz/onionskinmaskgui.cpp
@@ -10,8 +10,17 @@
 #include "toonz/txshsimplelevel.h"
 
 #include "toonz/onionskinmask.h"
+#include "toonzqt/menubarcommand.h"
+#include "menubarcommandids.h"
 
 #include <QMenu>
+
+namespace {
+OnioniSkinMaskGUI::OnionSkinSwitcher &onionSkinSwitcher() {
+  static OnioniSkinMaskGUI::OnionSkinSwitcher switcher;
+  return switcher;
+}
+}  // namespace
 
 //=============================================================================
 // OnioniSkinMaskGUI::OnionSkinSwitcher
@@ -100,14 +109,25 @@ void OnioniSkinMaskGUI::OnionSkinSwitcher::clearMOS() {
 }
 
 void OnioniSkinMaskGUI::OnionSkinSwitcher::clearOS() {
+  if (!isActive()) return;
   clearFOS();
   clearMOS();
 }
 
 //------------------------------------------------------------------------------
 
+void OnioniSkinMaskGUI::initializeCommands() {
+  OnionSkinSwitcher &switcher = onionSkinSwitcher();
+  QAction *action =
+      CommandManager::instance()->getAction(MI_ClearAllOnionSkinMarkers);
+  QObject::connect(action, SIGNAL(triggered()), &switcher, SLOT(clearOS()),
+                   Qt::UniqueConnection);
+}
+
+//------------------------------------------------------------------------------
+
 void OnioniSkinMaskGUI::addOnionSkinCommand(QMenu *menu, bool isFilmStrip) {
-  static OnioniSkinMaskGUI::OnionSkinSwitcher switcher;
+  OnionSkinSwitcher &switcher = onionSkinSwitcher();
   if (switcher.isActive()) {
     QAction *dectivateOnionSkin =
         menu->addAction(QString(QObject::tr("Deactivate Onion Skin")));
@@ -127,10 +147,8 @@ void OnioniSkinMaskGUI::addOnionSkinCommand(QMenu *menu, bool isFilmStrip) {
       }
       OnionSkinMask osm = switcher.getMask();
       if (osm.getFosCount() || osm.getMosCount()) {
-        QAction *clearAllOnionSkins = menu->addAction(
-            QString(QObject::tr("Clear All Onion Skin Markers")));
-        menu->connect(clearAllOnionSkins, SIGNAL(triggered()), &switcher,
-                      SLOT(clearOS()));
+        menu->addAction(CommandManager::instance()->getAction(
+            MI_ClearAllOnionSkinMarkers));
       }
       if (osm.getFosCount() && osm.getMosCount()) {
         QAction *clearFixedOnionSkins = menu->addAction(

--- a/toonz/sources/toonz/onionskinmaskgui.h
+++ b/toonz/sources/toonz/onionskinmaskgui.h
@@ -14,6 +14,7 @@ namespace OnioniSkinMaskGUI {
 
 // Da fare per la filmstrip!!
 void addOnionSkinCommand(QMenu *, bool isFilmStrip = false);
+void initializeCommands();
 
 void resetShiftTraceFrameOffset();
 

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -62,6 +62,7 @@ RowArea::RowArea(XsheetViewer *parent, Qt::WindowFlags flags)
   // for displaying the pinned center keys when the skeleton tool is selected
   connect(TApp::instance()->getCurrentTool(), SIGNAL(toolSwitched()), this,
           SLOT(update()));
+  OnioniSkinMaskGUI::initializeCommands();
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Adds a reusable Clear All Onion Skin Markers command to the onion-skin menu. The command can be assigned a shortcut and clears fixed and relative markers through the active onion-skin switcher.