### PR TITLE
[T2D-128] Set markers to selected cell range

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2289,6 +2289,8 @@ void MainWindow::defineActions() {
                          "prev_nav_tag");
   createMenuXsheetAction(MI_EditTaggedFrame, QT_TR_NOOP("Edit Tag"), "", "");
   createMenuXsheetAction(MI_ClearTags, QT_TR_NOOP("Remove Tags"), "", "");
+  createMenuXsheetAction(MI_PreviewSelected,
+                         QT_TR_NOOP("Set Markers to Selected Range"), "");
   CommandManager::instance()->enable(MI_NextTaggedFrame, false);
   CommandManager::instance()->enable(MI_PrevTaggedFrame, false);
   CommandManager::instance()->enable(MI_EditTaggedFrame, false);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -147,6 +147,8 @@
 #define MI_InsertFx "MI_InsertFx"
 #define MI_NewOutputFx "MI_NewOutputFx"
 
+#define MI_PreviewSelected "MI_PreviewSelected"
+
 #define MI_PasteNew "MI_PasteNew"
 #define MI_Autorenumber "MI_Autorenumber"
 #define MI_CreateBlankDrawing "MI_CreateBlankDrawing"

--- a/toonz/sources/toonz/xsheetcmd.cpp
+++ b/toonz/sources/toonz/xsheetcmd.cpp
@@ -51,6 +51,7 @@
 #include "toonzqt/stageobjectsdata.h"
 #include "historytypes.h"
 #include "xsheetviewer.h"
+#include "xsheetdragtool.h"
 
 // Tnz6 includes
 #include "cellselection.h"
@@ -2196,6 +2197,33 @@ SetCellMarkCommand CellMarkCommand8(8);
 SetCellMarkCommand CellMarkCommand9(9);
 SetCellMarkCommand CellMarkCommand10(10);
 SetCellMarkCommand CellMarkCommand11(11);
+
+//============================================================
+
+class PreviewSelected final : public MenuItemHandler {
+public:
+  PreviewSelected() : MenuItemHandler(MI_PreviewSelected) {}
+
+  void execute() override {
+    TSelection *selection =
+        TApp::instance()->getCurrentSelection()->getSelection();
+    TCellSelection *cellSelection = dynamic_cast<TCellSelection *>(selection);
+    if (!cellSelection) return;
+
+    int firstRow = 0;
+    int firstColumn = 0;
+    int lastRow = 0;
+    int lastColumn = 0;
+    cellSelection->getSelectedCells(firstRow, firstColumn, lastRow, lastColumn);
+
+    int playStart = 0;
+    int playStop  = 0;
+    int step      = 1;
+    XsheetGUI::getPlayRange(playStart, playStop, step);
+    XsheetGUI::setPlayRange(firstRow, lastRow, step);
+    TApp::instance()->getCurrentXsheetViewer()->update();
+  }
+} PreviewSelected;
 
 //============================================================
 

--- a/toonz/sources/toonz/xshrowviewer.cpp
+++ b/toonz/sources/toonz/xshrowviewer.cpp
@@ -1367,6 +1367,9 @@ void RowArea::contextMenuEvent(QContextMenuEvent *event) {
   QAction *previewThis = menu->addAction(tr("Preview This"));
   connect(previewThis, SIGNAL(triggered()), SLOT(onPreviewThis()));
 
+  menu->addAction(
+      CommandManager::instance()->getAction(MI_PreviewSelected));
+
   menu->addSeparator();
 
   if (Preferences::instance()->isOnionSkinEnabled()) {


### PR DESCRIPTION
Adds a shortcut-assignable Xsheet command that sets playback start and stop markers to the selected cell range. The row-header context menu exposes the same command.