### PR TITLE
[T2D-126] Create palette styles from current style

### DIFF
--- a/toonz/sources/toonzqt/paletteviewergui.cpp
+++ b/toonz/sources/toonzqt/paletteviewergui.cpp
@@ -1004,7 +1004,11 @@ void PageViewer::mousePressEvent(QMouseEvent *event) {
   if (indexInPage < 0 || indexInPage >= getChipCount()) {
     if (ShowNewStyleButton && indexInPage == getChipCount() &&
         !m_page->getPalette()->isLocked()) {
+      TColorStyleP currentStyle = getPaletteHandle()->getStyle();
       PaletteCmd::createStyle(getPaletteHandle(), getPage());
+      if (currentStyle)
+        getPaletteHandle()->getPalette()->setStyle(
+            getPaletteHandle()->getStyleIndex(), currentStyle->clone());
       m_styleSelection->select(pageIndex);
       m_styleSelection->select(pageIndex, indexInPage, true);
     } else {
@@ -1113,7 +1117,11 @@ void PageViewer::createMenuAction(QMenu &menu, const char *id, QString name,
 //-----------------------------------------------------------------------------
 
 void PageViewer::addNewColor() {
+  TColorStyleP currentStyle = getPaletteHandle()->getStyle();
   PaletteCmd::createStyle(getPaletteHandle(), getPage());
+  if (currentStyle)
+    getPaletteHandle()->getPalette()->setStyle(
+        getPaletteHandle()->getStyleIndex(), currentStyle->clone());
   computeSize();
   update();
 }


### PR DESCRIPTION
Makes both new-style entry points clone the current palette style instead of creating a default color chip.