### PR TITLE
(Feature) Properly expose FFmpeg WebP support

### DIFF
--- a/toonz/sources/image/CMakeLists.txt
+++ b/toonz/sources/image/CMakeLists.txt
@@ -17,6 +17,7 @@ set(HEADERS
     mov/tiio_mov_proxy.h
     3gp/tiio_3gp_proxy.h
     ffmpeg/tiio_gif.h
+    ffmpeg/tiio_webp.h
     ffmpeg/tiio_webm.h
     ffmpeg/tiio_apng.h
     ffmpeg/tiio_mp4.h
@@ -49,6 +50,7 @@ set(SOURCES
     mov/tiio_mov_proxy.cpp
     3gp/tiio_3gp_proxy.cpp
     ffmpeg/tiio_gif.cpp
+    ffmpeg/tiio_webp.cpp
     ffmpeg/tiio_webm.cpp
     ffmpeg/tiio_apng.cpp
     ffmpeg/tiio_mp4.cpp

--- a/toonz/sources/image/ffmpeg/tiio_webp.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_webp.cpp
@@ -11,9 +11,14 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QHash>
 #include <QImage>
+#include <QMutex>
+#include <QMutexLocker>
 #include <QProcess>
+#include <QSharedPointer>
 #include <QStringList>
+#include <QWaitCondition>
 
 #include <cstring>
 
@@ -46,6 +51,28 @@ double parseFrameRate(const QString &value) {
   if (!numeratorOk || !denominatorOk || denominator == 0.0) return 0.0;
 
   return numerator / denominator;
+}
+
+enum class WebPCacheStatus { NotStarted, Extracting, Ready, Failed };
+
+struct WebPCacheState {
+  QMutex mutex;
+  QWaitCondition finished;
+  WebPCacheStatus status = WebPCacheStatus::NotStarted;
+  int frameCount         = 0;
+};
+
+QMutex s_webpCacheRegistryMutex;
+QHash<QString, QSharedPointer<WebPCacheState>> s_webpCacheRegistry;
+
+QSharedPointer<WebPCacheState> webpCacheState(const QString &cacheKey) {
+  QMutexLocker locker(&s_webpCacheRegistryMutex);
+  auto state = s_webpCacheRegistry.value(cacheKey);
+  if (!state) {
+    state = QSharedPointer<WebPCacheState>::create();
+    s_webpCacheRegistry.insert(cacheKey, state);
+  }
+  return state;
 }
 
 class TImageReaderWebP final : public TImageReader {
@@ -106,9 +133,18 @@ TLevelReaderWebP::TLevelReaderWebP(const TFilePath &path)
   QFileInfo fileInfo(path.getQString());
   QString fullPath = fileInfo.absoluteFilePath();
   if (fullPath.isEmpty()) fullPath = path.getQString();
-  const QByteArray hash =
-      QCryptographicHash::hash(fullPath.toUtf8(), QCryptographicHash::Md5);
-  m_tempBaseName = QString::fromLatin1(hash.toHex().left(12)) + "_webp";
+
+  // Include source identity, size and modification time so replacing a WebP at
+  // the same path cannot reuse frames extracted from an older file.
+  QByteArray cacheIdentity = fullPath.toUtf8();
+  cacheIdentity.append('|');
+  cacheIdentity.append(QByteArray::number(fileInfo.size()));
+  cacheIdentity.append('|');
+  cacheIdentity.append(
+      QByteArray::number(fileInfo.lastModified().toMSecsSinceEpoch()));
+  const QByteArray hash = QCryptographicHash::hash(
+      cacheIdentity, QCryptographicHash::Md5);
+  m_tempBaseName = QString::fromLatin1(hash.toHex().left(16)) + "_webp";
 
   QStringList probeArgs;
   probeArgs << "-v" << "error" << "-select_streams" << "v:0"
@@ -167,7 +203,9 @@ TLevelReaderWebP::TLevelReaderWebP(const TFilePath &path)
 //-----------------------------------------------------------------------------
 
 TLevelReaderWebP::~TLevelReaderWebP() {
-  removeExtractedFrames();
+  // Extracted frames are shared by Level Strip, Xsheet and viewer readers.
+  // Removing them here races with other active readers and causes repeated
+  // extraction attempts and misleading failure dialogs while scrubbing.
   delete m_imageInfo;
 }
 
@@ -250,30 +288,58 @@ int TLevelReaderWebP::countExtractedFrames() const {
 //-----------------------------------------------------------------------------
 
 bool TLevelReaderWebP::ensureFramesExtracted() {
-  if (m_framesExtracted) return true;
+  if (m_framesExtracted && countExtractedFrames() == m_frameCount) return true;
 
-  removeExtractedFrames();
+  const auto sharedState = webpCacheState(m_tempBaseName);
+  {
+    QMutexLocker locker(&sharedState->mutex);
+    while (sharedState->status == WebPCacheStatus::Extracting)
+      sharedState->finished.wait(&sharedState->mutex);
 
-  // Explicitly ignore the WebP loop count and cap output at the exact decoded
-  // source-frame count. Passthrough timing prevents FFmpeg from duplicating held
-  // frames to make a constant-rate image sequence.
-  bool extracted = extractFrames(true, m_frameCount);
-  if (!extracted) {
-    // Older FFmpeg builds can decode still WebP through image2 but do not have
-    // the animated WebP demuxer's ignore_loop option.
+    if (sharedState->status == WebPCacheStatus::Ready &&
+        sharedState->frameCount == m_frameCount &&
+        countExtractedFrames() == m_frameCount) {
+      m_framesExtracted = true;
+      return true;
+    }
+
+    if (sharedState->status == WebPCacheStatus::Failed) return false;
+
+    sharedState->status = WebPCacheStatus::Extracting;
+  }
+
+  // Only the reader that changed the shared state to Extracting reaches here.
+  // Other Level Strip, Xsheet and viewer readers wait and then reuse its files.
+  bool extracted = false;
+  int extractedFrameCount = countExtractedFrames();
+  if (extractedFrameCount == m_frameCount) {
+    extracted = true;
+  } else {
     removeExtractedFrames();
-    extracted = extractFrames(false, m_frameCount);
+
+    // Explicitly ignore the WebP loop count and cap output at the exact decoded
+    // source-frame count. Passthrough timing prevents FFmpeg from duplicating
+    // held frames to make a constant-rate image sequence.
+    extracted = extractFrames(true, m_frameCount);
+    if (!extracted) {
+      // Older FFmpeg builds can decode still WebP through image2 but do not have
+      // the animated WebP demuxer's ignore_loop option.
+      removeExtractedFrames();
+      extracted = extractFrames(false, m_frameCount);
+    }
+    extractedFrameCount = countExtractedFrames();
+    extracted = extracted && extractedFrameCount == m_frameCount;
+  }
+
+  {
+    QMutexLocker locker(&sharedState->mutex);
+    sharedState->frameCount = extracted ? m_frameCount : 0;
+    sharedState->status =
+        extracted ? WebPCacheStatus::Ready : WebPCacheStatus::Failed;
+    sharedState->finished.wakeAll();
   }
 
   if (!extracted) {
-    removeExtractedFrames();
-    DVGui::warning(QObject::tr("FFmpeg failed to decode WebP file: %1")
-                       .arg(m_path.getQString()));
-    return false;
-  }
-
-  const int extractedFrameCount = countExtractedFrames();
-  if (extractedFrameCount != m_frameCount) {
     removeExtractedFrames();
     DVGui::warning(
         QObject::tr("FFmpeg decoded %1 of %2 expected WebP frames from: %3")

--- a/toonz/sources/image/ffmpeg/tiio_webp.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_webp.cpp
@@ -1,0 +1,339 @@
+#include "tiio_webp.h"
+
+#include "thirdparty.h"
+#include "timageinfo.h"
+#include "tmsgcore.h"
+#include "tsystem.h"
+#include "toonz/stage.h"
+#include "toonz/toonzfolders.h"
+
+#include <QCryptographicHash>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QImage>
+#include <QProcess>
+#include <QStringList>
+
+#include <cstring>
+
+namespace {
+
+int ffmpegTimeoutMs() {
+  const int timeoutSeconds = ThirdParty::getFFmpegTimeout();
+  return timeoutSeconds > 0 ? timeoutSeconds * 1000 : 30000;
+}
+
+bool waitForProcess(QProcess &process) {
+  if (!process.waitForFinished(ffmpegTimeoutMs())) {
+    process.kill();
+    process.waitForFinished(1000);
+    return false;
+  }
+
+  return process.exitStatus() == QProcess::NormalExit &&
+         process.exitCode() == 0;
+}
+
+double parseFrameRate(const QString &value) {
+  const QStringList values = value.trimmed().split('/');
+  if (values.size() != 2) return 0.0;
+
+  bool numeratorOk         = false;
+  bool denominatorOk       = false;
+  const double numerator   = values.at(0).toDouble(&numeratorOk);
+  const double denominator = values.at(1).toDouble(&denominatorOk);
+  if (!numeratorOk || !denominatorOk || denominator == 0.0) return 0.0;
+
+  return numerator / denominator;
+}
+
+class TImageReaderWebP final : public TImageReader {
+public:
+  TImageReaderWebP(const TFilePath &path, int frameIndex,
+                   TLevelReaderWebP *levelReader, TImageInfo *info)
+      : TImageReader(path)
+      , m_frameIndex(frameIndex)
+      , m_levelReader(levelReader)
+      , m_info(info) {
+    if (m_levelReader) m_levelReader->addRef();
+  }
+
+  ~TImageReaderWebP() override {
+    if (m_levelReader) m_levelReader->release();
+  }
+
+  TImageP load() override {
+    return m_levelReader ? m_levelReader->load(m_frameIndex) : TImageP();
+  }
+
+  TDimension getSize() const {
+    return m_levelReader ? m_levelReader->getSize() : TDimension();
+  }
+
+  TRect getBBox() const { return TRect(); }
+
+  const TImageInfo *getImageInfo() const override { return m_info; }
+
+private:
+  int m_frameIndex;
+  TLevelReaderWebP *m_levelReader;
+  TImageInfo *m_info;
+
+  TImageReaderWebP(const TImageReaderWebP &)            = delete;
+  TImageReaderWebP &operator=(const TImageReaderWebP &) = delete;
+};
+
+}  // namespace
+
+//=============================================================================
+// TLevelReaderWebP
+//-----------------------------------------------------------------------------
+
+TLevelReaderWebP::TLevelReaderWebP(const TFilePath &path)
+    : TLevelReader(path) {
+  QString cacheRoot = ToonzFolder::getCacheRootFolder().getQString();
+  TFilePath cachePath(cacheRoot + "/ffmpeg");
+  if (!TSystem::doesExistFileOrLevel(cachePath)) {
+    try {
+      TSystem::mkDir(cachePath);
+    } catch (const TSystemException &) {
+      throw TImageException(path, "Cannot create FFmpeg cache directory.");
+    }
+  }
+  m_cacheDir = cachePath.getQString();
+
+  QFileInfo fileInfo(path.getQString());
+  QString fullPath = fileInfo.absoluteFilePath();
+  if (fullPath.isEmpty()) fullPath = path.getQString();
+  const QByteArray hash =
+      QCryptographicHash::hash(fullPath.toUtf8(), QCryptographicHash::Md5);
+  m_tempBaseName = QString::fromLatin1(hash.toHex().left(12)) + "_webp";
+
+  QStringList probeArgs;
+  probeArgs << "-v" << "error" << "-select_streams" << "v:0"
+            << "-show_entries"
+            << "stream=width,height,avg_frame_rate,r_frame_rate" << "-of"
+            << "default=noprint_wrappers=1" << path.getQString();
+
+  QProcess ffprobe;
+  ThirdParty::runFFprobe(ffprobe, probeArgs);
+  if (!waitForProcess(ffprobe)) {
+    throw TImageException(path, "Unable to probe WebP image information.");
+  }
+
+  const QString output =
+      QString::fromUtf8(ffprobe.readAllStandardOutput());
+  ffprobe.close();
+
+  int width          = 0;
+  int height         = 0;
+  double averageRate = 0.0;
+  double nominalRate = 0.0;
+
+  const QStringList lines = output.split('\n', Qt::SkipEmptyParts);
+  for (const QString &line : lines) {
+    if (line.startsWith("width="))
+      width = line.section('=', 1, 1).toInt();
+    else if (line.startsWith("height="))
+      height = line.section('=', 1, 1).toInt();
+    else if (line.startsWith("avg_frame_rate="))
+      averageRate = parseFrameRate(line.section('=', 1, 1));
+    else if (line.startsWith("r_frame_rate="))
+      nominalRate = parseFrameRate(line.section('=', 1, 1));
+  }
+
+  if (width <= 0 || height <= 0)
+    throw TImageException(path, "Invalid WebP image dimensions.");
+
+  // Count decoded frames rather than estimating duration x frame rate. Animated
+  // WebP supports variable frame delays, so the estimate can be many times
+  // larger than the number of source animation frames.
+  m_frameCount = probeFrameCount(true);
+  if (m_frameCount <= 0) m_frameCount = probeFrameCount(false);
+  if (m_frameCount <= 0) m_frameCount = 1;
+
+  m_size      = TDimension(width, height);
+  m_imageInfo = new TImageInfo();
+  m_imageInfo->m_frameRate = averageRate > 0.0 ? averageRate : nominalRate;
+  m_imageInfo->m_lx             = width;
+  m_imageInfo->m_ly             = height;
+  m_imageInfo->m_bitsPerSample  = 8;
+  m_imageInfo->m_samplePerPixel = 4;
+  m_imageInfo->m_dpix           = Stage::standardDpi;
+  m_imageInfo->m_dpiy           = Stage::standardDpi;
+}
+
+//-----------------------------------------------------------------------------
+
+TLevelReaderWebP::~TLevelReaderWebP() {
+  removeExtractedFrames();
+  delete m_imageInfo;
+}
+
+//-----------------------------------------------------------------------------
+
+QString TLevelReaderWebP::getFramePattern() const {
+  return m_cacheDir + QDir::separator() + m_tempBaseName + "_%06d.png";
+}
+
+//-----------------------------------------------------------------------------
+
+QString TLevelReaderWebP::getFramePath(int frameIndex) const {
+  return m_cacheDir + QDir::separator() + m_tempBaseName + "_" +
+         QString("%1").arg(frameIndex, 6, 10, QChar('0')) + ".png";
+}
+
+//-----------------------------------------------------------------------------
+
+void TLevelReaderWebP::removeExtractedFrames() {
+  if (m_cacheDir.isEmpty() || m_tempBaseName.isEmpty()) return;
+
+  QDir cacheDirectory(m_cacheDir);
+  const QStringList files = cacheDirectory.entryList(
+      QStringList() << m_tempBaseName + "_*.png", QDir::Files);
+  for (const QString &file : files) QFile::remove(cacheDirectory.filePath(file));
+
+  m_framesExtracted = false;
+}
+
+//-----------------------------------------------------------------------------
+
+int TLevelReaderWebP::probeFrameCount(bool ignoreLoop) const {
+  QStringList args;
+  args << "-v" << "error";
+  if (ignoreLoop) args << "-ignore_loop" << "1";
+  args << "-count_frames" << "-select_streams" << "v:0"
+       << "-show_entries" << "stream=nb_read_frames" << "-of"
+       << "default=noprint_wrappers=1:nokey=1" << m_path.getQString();
+
+  QProcess ffprobe;
+  ThirdParty::runFFprobe(ffprobe, args);
+  if (!waitForProcess(ffprobe)) return 0;
+
+  bool ok = false;
+  const int frameCount =
+      QString::fromUtf8(ffprobe.readAllStandardOutput()).trimmed().toInt(&ok);
+  ffprobe.close();
+
+  return ok && frameCount > 0 ? frameCount : 0;
+}
+
+//-----------------------------------------------------------------------------
+
+bool TLevelReaderWebP::extractFrames(bool ignoreLoop, int frameLimit) {
+  QStringList args;
+  args << "-hide_banner" << "-loglevel" << "error";
+  if (ignoreLoop) args << "-ignore_loop" << "1";
+  args << "-threads" << "auto" << "-i" << m_path.getQString() << "-map"
+       << "0:v:0" << "-fps_mode" << "passthrough";
+  if (frameLimit > 0)
+    args << "-frames:v" << QString::number(frameLimit);
+  args << "-pix_fmt" << "rgba" << "-start_number" << "1" << "-y" << "-f"
+       << "image2" << getFramePattern();
+
+  QProcess ffmpeg;
+  ThirdParty::runFFmpeg(ffmpeg, args);
+  const bool success = waitForProcess(ffmpeg);
+  ffmpeg.close();
+  return success;
+}
+
+//-----------------------------------------------------------------------------
+
+int TLevelReaderWebP::countExtractedFrames() const {
+  int frameIndex = 1;
+  while (QFile::exists(getFramePath(frameIndex))) ++frameIndex;
+  return frameIndex - 1;
+}
+
+//-----------------------------------------------------------------------------
+
+bool TLevelReaderWebP::ensureFramesExtracted() {
+  if (m_framesExtracted) return true;
+
+  removeExtractedFrames();
+
+  // Explicitly ignore the WebP loop count and cap output at the exact decoded
+  // source-frame count. Passthrough timing prevents FFmpeg from duplicating held
+  // frames to make a constant-rate image sequence.
+  bool extracted = extractFrames(true, m_frameCount);
+  if (!extracted) {
+    // Older FFmpeg builds can decode still WebP through image2 but do not have
+    // the animated WebP demuxer's ignore_loop option.
+    removeExtractedFrames();
+    extracted = extractFrames(false, m_frameCount);
+  }
+
+  if (!extracted) {
+    removeExtractedFrames();
+    DVGui::warning(QObject::tr("FFmpeg failed to decode WebP file: %1")
+                       .arg(m_path.getQString()));
+    return false;
+  }
+
+  const int extractedFrameCount = countExtractedFrames();
+  if (extractedFrameCount != m_frameCount) {
+    removeExtractedFrames();
+    DVGui::warning(
+        QObject::tr("FFmpeg decoded %1 of %2 expected WebP frames from: %3")
+            .arg(extractedFrameCount)
+            .arg(m_frameCount)
+            .arg(m_path.getQString()));
+    return false;
+  }
+
+  m_framesExtracted = true;
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+
+TLevelP TLevelReaderWebP::loadInfo() {
+  TLevelP level;
+  for (int frameIndex = 1; frameIndex <= m_frameCount; ++frameIndex)
+    level->setFrame(frameIndex, TImageP());
+
+  return level;
+}
+
+//-----------------------------------------------------------------------------
+
+TImageReaderP TLevelReaderWebP::getFrameReader(TFrameId fid) {
+  if (!fid.getLetter().isEmpty()) return TImageReaderP(nullptr);
+
+  const int frameIndex = fid.getNumber();
+  if (frameIndex < 1 || frameIndex > m_frameCount)
+    return TImageReaderP(nullptr);
+
+  return TImageReaderP(
+      new TImageReaderWebP(m_path, frameIndex, this, m_imageInfo));
+}
+
+//-----------------------------------------------------------------------------
+
+TDimension TLevelReaderWebP::getSize() { return m_size; }
+
+//-----------------------------------------------------------------------------
+
+TImageP TLevelReaderWebP::load(int frameIndex) {
+  if (!ensureFramesExtracted() || frameIndex < 1 ||
+      frameIndex > m_frameCount)
+    return TImageP();
+
+  QImage image;
+  if (!image.load(getFramePath(frameIndex), "PNG")) return TImageP();
+  if (image.format() != QImage::Format_ARGB32)
+    image = image.convertToFormat(QImage::Format_ARGB32);
+
+  const int width  = image.width();
+  const int height = image.height();
+  TRasterPT<TPixelRGBM32> raster;
+  raster.create(width, height);
+  raster->lock();
+  std::memcpy(raster->getRawData(), image.constBits(), width * height * 4);
+  raster->unlock();
+  raster->yMirror();
+
+  return TRasterImageP(raster);
+}

--- a/toonz/sources/image/ffmpeg/tiio_webp.h
+++ b/toonz/sources/image/ffmpeg/tiio_webp.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#ifndef TTIO_WEBP_INCLUDED
+#define TTIO_WEBP_INCLUDED
+
+#include "tlevel_io.h"
+#include "trasterimage.h"
+#include "tgeometry.h"
+
+#include <QString>
+
+class TLevelReaderWebP final : public TLevelReader {
+public:
+  explicit TLevelReaderWebP(const TFilePath &path);
+  ~TLevelReaderWebP() override;
+
+  TImageReaderP getFrameReader(TFrameId fid) override;
+  TLevelP loadInfo() override;
+  TImageP load(int frameIndex);
+  TDimension getSize();
+
+  static TLevelReader *create(const TFilePath &path) {
+    return new TLevelReaderWebP(path);
+  }
+
+private:
+  bool ensureFramesExtracted();
+  bool extractFrames(bool ignoreLoop, int frameLimit);
+  int probeFrameCount(bool ignoreLoop) const;
+  int countExtractedFrames() const;
+  QString getFramePath(int frameIndex) const;
+  QString getFramePattern() const;
+  void removeExtractedFrames();
+
+  bool m_framesExtracted = false;
+  int m_frameCount       = 0;
+  TDimension m_size;
+  TImageInfo *m_imageInfo = nullptr;
+  QString m_cacheDir;
+  QString m_tempBaseName;
+};
+
+#endif  // TTIO_WEBP_INCLUDED

--- a/toonz/sources/image/tiio.cpp
+++ b/toonz/sources/image/tiio.cpp
@@ -40,6 +40,7 @@
 #include "./tzl/tiio_tzl.h"
 #include "./tzm/tiio_tzm.h"
 #include "./svg/tiio_svg.h"
+#include "./ffmpeg/tiio_webp.h"
 #include "./ffmpeg/tiio_gif.h"
 #include "./ffmpeg/tiio_webm.h"
 #include "./ffmpeg/tiio_mp4.h"
@@ -270,7 +271,7 @@ void initImageIo(bool lightVersion) {
     // Still WebP only requires a WebP decoder. Animated WebP support follows
     // the demuxing and decoding capabilities of the selected FFmpeg build.
     if (hasFFmpegDecoder("webp")) {
-      TLevelReader::define("webp", TLevelReaderFFmpeg::create);
+      TLevelReader::define("webp", TLevelReaderWebP::create);
       TFileType::declare("webp", TFileType::RASTER_LEVEL);
     }
     TLevelReader::define("ffvideo", TLevelReaderFFmpeg::create);

--- a/toonz/sources/image/tiio.cpp
+++ b/toonz/sources/image/tiio.cpp
@@ -18,6 +18,10 @@
 // why (it would be included anyway though)
 #include <math.h>
 
+#include <QDateTime>
+#include <QProcess>
+#include <QStringList>
+
 // Common includes
 #include "./quantel/tiio_quantel.h"
 #include "./sgi/tiio_sgi.h"
@@ -87,6 +91,48 @@
 #include "./mov/tiio_mov_proxy.h"
 #include "./3gp/tiio_3gp_proxy.h"
 #endif
+
+namespace {
+
+bool hasFFmpegDecoder(const QString &decoderName) {
+  // Cache with reload every hour, matching Ffmpeg::checkFormat().
+  static QString cachedDecoders;
+  static QDateTime lastCheck;
+
+  const QDateTime now = QDateTime::currentDateTime();
+  if (cachedDecoders.isEmpty() || lastCheck.secsTo(now) > 3600) {
+    QStringList args;
+    args << "-hide_banner" << "-decoders";
+
+    QProcess ffmpeg;
+    ThirdParty::runFFmpeg(ffmpeg, args);
+    if (!ffmpeg.waitForFinished(8000) ||
+        ffmpeg.exitStatus() != QProcess::NormalExit || ffmpeg.exitCode() != 0) {
+      ffmpeg.kill();
+      ffmpeg.waitForFinished(1000);
+      return false;
+    }
+
+    cachedDecoders =
+        ffmpeg.readAllStandardError() + ffmpeg.readAllStandardOutput();
+    ffmpeg.close();
+    lastCheck = now;
+  }
+
+  const QStringList lines = cachedDecoders.split('\n');
+  for (const QString &line : lines) {
+    const QStringList columns =
+        line.simplified().split(' ', Qt::SkipEmptyParts);
+    if (columns.size() >= 2 &&
+        columns.at(1).compare(decoderName, Qt::CaseInsensitive) == 0) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+}  // namespace
 
 //-------------------------------------------------------------------
 
@@ -221,8 +267,12 @@ void initImageIo(bool lightVersion) {
       TFileType::declare("apng", TFileType::RASTER_LEVEL);
       Tiio::defineWriterProperties("apng", new Tiio::APngWriterProperties());
     }
-    TLevelReader::define("webp", TLevelReaderFFmpeg::create);
-    TFileType::declare("webp", TFileType::RASTER_LEVEL);
+    // Still WebP only requires a WebP decoder. Animated WebP support follows
+    // the demuxing and decoding capabilities of the selected FFmpeg build.
+    if (hasFFmpegDecoder("webp")) {
+      TLevelReader::define("webp", TLevelReaderFFmpeg::create);
+      TFileType::declare("webp", TFileType::RASTER_LEVEL);
+    }
     TLevelReader::define("ffvideo", TLevelReaderFFmpeg::create);
     TFileType::declare("ffvideo", TFileType::RASTER_LEVEL);
   }


### PR DESCRIPTION
## Summary

Properly expose FFmpeg-backed WebP import according to the capabilities of the FFmpeg executable selected in OpenToonz.

- Query `ffmpeg -decoders` and match the exact `webp` decoder name before advertising `.webp`.
- Use a dedicated WebP level reader rather than the generic constant-rate movie reader.
- Count decoded source frames with FFprobe's `nb_read_frames` instead of estimating `duration × frame rate`.
- Explicitly ignore embedded WebP looping during import.
- Extract with passthrough frame timing so long frame delays do not become duplicated OpenToonz drawings.
- Cap FFmpeg extraction at the probed source-frame count and verify that the exact number of PNG intermediates was produced.
- Preserve alpha through RGBA PNG intermediates.
- Share one extraction cache across Level Strip, Xsheet and viewer readers so scrubbing and thumbnail generation cannot delete or overwrite each other's frames.

## Why

OpenToonz-Dev already contained a partial WebP registration, but it was enabled whenever FFmpeg itself was found. That could advertise WebP even when the selected FFmpeg build had no WebP decoder.

The original implementation also routed WebP through the generic FFmpeg movie reader. That reader derives frame count from duration and nominal frame rate when those fields are available. Animated WebP supports variable per-frame delays, so this can report many more frames than the source animation contains. Normal FFmpeg image-sequence synchronization can then duplicate held frames, making loading appear not to terminate cleanly.

The dedicated reader treats WebP as an image animation rather than a constant-frame-rate movie. Each decoded WebP source frame becomes exactly one OpenToonz raster-level frame.

Application testing also exposed a cache-lifecycle race: separate readers used by the Level Strip, Xsheet and viewer could share the same temporary filenames while each reader destructor removed them. Scrubbing while thumbnails were still appearing could therefore trigger redundant extraction attempts and repeated failure dialogs even though the level had loaded correctly.

The cache is now keyed by source path, size and modification time, extraction is coordinated through shared per-source state, waiting readers reuse the completed frame set, and successful cached frames are no longer deleted by individual reader destructors.

This also avoids the common WebP/WebM confusion: WebP is an image/animation format; WebM remains the separately registered video format.

## Compatibility behavior

- Still WebP requires an FFmpeg WebP decoder.
- Animated WebP additionally follows the demuxing and animation capabilities of the configured FFmpeg build.
- The reader first uses the animated WebP demuxer's `ignore_loop` option. It retries without that option for older FFmpeg builds that can decode still WebP through the image input path.
- Variable source delays are not stored as independent OpenToonz timing metadata. The imported result is one sequential level frame per source WebP frame.
- Multiple OpenToonz readers for the same unchanged source reuse one validated extracted-frame cache.

## Scope

This PR is **import/loading only**.

It does not add a WebP writer, rendering settings, quality controls, lossless/lossy options, loop controls, or output-format registration. Those belong in the separate WebP rendering/export PR.

## Validation performed

- Confirmed exact decoder-name matching against real FFmpeg decoder output.
- Generated and loaded a lossless still WebP with transparency using FFmpeg 7.1.3 command-line behavior.
- Reproduced the variable-delay synchronization problem with a three-frame animation: default image-sequence output expanded three source frames to fourteen files, while passthrough timing produced exactly three.
- Added an explicit frame cap and post-extraction count check so a mismatch fails cleanly instead of leaving OpenToonz waiting on nonexistent frames.
- Reproduced repeated warning dialogs while scrubbing successfully loaded 12-frame and 200+ frame animated WebP levels as Level Strip thumbnails populated.
- Changed extraction ownership so concurrent Level Strip, Xsheet and viewer readers wait for and reuse one completed extraction instead of deleting or recreating shared files.
- Full OpenToonz platform builds and application-level regression tests remain for CI/artifact validation.

## Suggested application testing

1. Load a still WebP with alpha and confirm a one-frame raster level.
2. Load the attached-style 12-frame infinite-loop WebP, scrub while Level Strip icons populate, and confirm no warning dialogs appear.
3. Load only 24 frames from a 200+ frame WebP, scrub immediately, and confirm thumbnail generation and viewer access do not trigger re-extraction dialogs.
4. Load an animated WebP with unequal frame delays and confirm one OpenToonz drawing per source WebP frame.
5. Confirm an infinite loop imports only one source cycle.
6. Replace a WebP file at the same path and confirm the changed file does not reuse stale extracted frames.
7. Confirm existing WebM, GIF, APNG, MP4 and MOV behavior is unchanged.
