### PR TITLE
[windows-fail] Validate staged CI gating

### DIFF
--- a/.github/workflows/ci-gate-probe.yml
+++ b/.github/workflows/ci-gate-probe.yml
@@ -1,0 +1,85 @@
+name: CI Gate Probe
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-gate-probe-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+
+jobs:
+  Windows:
+    runs-on: windows-2025
+    timeout-minutes: 10
+    steps:
+      - name: Record Windows start
+        shell: pwsh
+        run: Write-Host "Windows probe started at $([DateTime]::UtcNow.ToString('o'))"
+
+      - name: Allow cancellation to be observed
+        shell: pwsh
+        run: Start-Sleep -Seconds 30
+
+      - name: Force Windows failure when requested
+        if: contains(github.event.pull_request.title, '[windows-fail]')
+        shell: pwsh
+        run: |
+          Write-Error "Intentional Windows gate failure for CI orchestration testing."
+          exit 1
+
+      - name: Windows gate passed
+        shell: pwsh
+        run: Write-Host "Windows gate passed."
+
+  Ubuntu:
+    needs: Windows
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    strategy:
+      fail-fast: true
+      matrix:
+        compiler: [gcc, clang]
+    steps:
+      - name: Record Ubuntu start
+        run: echo "Ubuntu ${{ matrix.compiler }} probe started at $(date -u +%FT%TZ)"
+
+      - name: Force Ubuntu GCC failure when requested
+        if: matrix.compiler == 'gcc' && contains(github.event.pull_request.title, '[ubuntu-fail]')
+        run: |
+          echo "Intentional Ubuntu gate failure for CI orchestration testing."
+          exit 1
+
+      - name: Ubuntu compiler gate passed
+        run: echo "Ubuntu ${{ matrix.compiler }} gate passed."
+
+  Fedora:
+    needs: Ubuntu
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: fedora:latest
+    steps:
+      - name: Record Fedora start
+        run: echo "Fedora probe started at $(date -u +%FT%TZ)"
+      - name: Fedora final gate passed
+        run: echo "Fedora final gate passed."
+
+  macOS:
+    needs: Ubuntu
+    runs-on: macos-15-intel
+    timeout-minutes: 10
+    steps:
+      - name: Record macOS start
+        run: echo "macOS probe started at $(date -u +%FT%TZ)"
+      - name: macOS final gate passed
+        run: echo "macOS final gate passed."

--- a/ci-scripts/staged-ci-probe.md
+++ b/ci-scripts/staged-ci-probe.md
@@ -1,0 +1,16 @@
+# Staged CI validation probe
+
+This file intentionally changes a non-documentation path so the production CI
+workflow runs without changing OpenToonz source code.
+
+The accompanying temporary workflow validates orchestration behavior:
+
+1. A superseded pull-request run is cancelled.
+2. A Windows failure prevents Ubuntu, Fedora, and macOS from starting.
+3. An Ubuntu failure occurs only after Windows succeeds and prevents Fedora and
+   macOS from starting.
+4. A successful Ubuntu matrix allows Fedora and macOS to start independently.
+5. The production CI performs a complete staged OpenToonz build and produces
+   the expected artifacts.
+
+This probe PR is disposable and must not be merged.


### PR DESCRIPTION
## Purpose

Exercise the newly consolidated CI without changing OpenToonz source code.

This disposable draft PR runs two complementary tests:

1. The production `CI` workflow performs a real staged OpenToonz build: Windows → Ubuntu GCC/Clang → Fedora and macOS.
2. A temporary short `CI Gate Probe` workflow deliberately tests cancellation and failure propagation without spending full build time on known-failure cases.

## Test phases

- **Cancellation and Windows gate:** change the title to include `[windows-fail]`. The prior probe run should be cancelled; Windows should fail and all later jobs should be skipped.
- **Ubuntu gate:** replace that tag with `[ubuntu-fail]`. Windows should pass, Ubuntu GCC should fail, and Fedora/macOS should be skipped.
- **Successful graph:** remove all failure tags. Windows and both Ubuntu jobs should pass, then Fedora and macOS should start independently.
- **Production workflow:** confirm only one PR-triggered production CI run survives after a synchronization commit, that its job ordering matches the intended graph, and that Windows, Ubuntu GCC, and macOS artifacts are produced.

## Important

This PR is a test fixture. It must be closed rather than merged after results are recorded.

The test also documents an issue discovered after PR #63 merged: the merge commit ran CodeQL but did not run production CI. The production workflow currently re-includes `.github/workflows/ci.yml`, although its actual path is `.github/workflows/workflow_windows.yml`; that self-trigger path should be corrected in a separate permanent change.