### PR TITLE
[T2D-138] Add Segment Eraser and synchronized Savebox controls

### DIFF
--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -593,9 +593,10 @@ protected slots:
 class EraserToolOptionsBox final : public ToolOptionsBox {
   Q_OBJECT
 
-  ToolOptionCheckbox *m_pencilMode, *m_invertMode, *m_multiFrameMode;
+  ToolOptionCheckbox *m_pencilMode, *m_invertMode, *m_multiFrameMode,
+      *m_eraseOnlySavebox;
   ToolOptionCombo *m_toolType, *m_colorMode;
-  QLabel *m_hardnessLabel;
+  QLabel *m_hardnessLabel, *m_colorModeLabel;
   ToolOptionSlider *m_hardnessField;
 
 public:

--- a/toonz/sources/include/toonz/autoclose.h
+++ b/toonz/sources/include/toonz/autoclose.h
@@ -47,6 +47,10 @@ struct AutocloseSettings {
 };
 
 class DVAPI TAutocloser {
+  static std::string segmentCacheKey(const std::string &id) {
+    return Preferences::instance()->getFillOnlySavebox() ? id + "s" : id;
+  }
+
 public:
   typedef std::pair<TPoint, TPoint> Segment;
 
@@ -69,13 +73,13 @@ public:
 
   // Cache management functions
   static bool hasSegmentCache(const std::string &id) {
+    std::string cacheKey = segmentCacheKey(id);
     std::lock_guard<std::mutex> lock(m_mutex);
-    return m_cache.find(id) != m_cache.end();
+    return m_cache.find(cacheKey) != m_cache.end();
   }
 
   static const std::vector<Segment> &getSegmentCache(const std::string &id) {
-    std::string cacheKey =
-        Preferences::instance()->getFillOnlySavebox() ? id + "s" : id;
+    std::string cacheKey = segmentCacheKey(id);
     std::lock_guard<std::mutex> lock(m_mutex);
     auto it = m_cache.find(cacheKey);
     if (it != m_cache.end()) {
@@ -87,8 +91,7 @@ public:
 
   static void setSegmentCache(const std::string &id,
                               const std::vector<Segment> &segments) {
-    std::string cacheKey =
-        Preferences::instance()->getFillOnlySavebox() ? id + "s" : id;
+    std::string cacheKey = segmentCacheKey(id);
     std::lock_guard<std::mutex> lock(m_mutex);
 
     constexpr size_t MAX_CACHE_SIZE = 50;  // maximum number of images in cache

--- a/toonz/sources/include/toonz/fill.h
+++ b/toonz/sources/include/toonz/fill.h
@@ -101,7 +101,7 @@ DVAPI void inkFill(const TRasterCM32P &r, const TPoint &p, int ink,
 
 bool DVAPI inkSegment(const TRasterCM32P &r, const TPoint &p, int ink,
                       float growFactor, bool isSelective,
-                      TTileSaverCM32 *saver = 0);
+                      TTileSaverCM32 *saver = 0, bool clearInk = false);
 
 void DVAPI rectFillInk(const TRasterCM32P &ras, const TRect &r, int color);
 

--- a/toonz/sources/include/toonz/preferences.h
+++ b/toonz/sources/include/toonz/preferences.h
@@ -581,6 +581,7 @@ Q_SIGNALS:
   void stopAutoSave();
   void startAutoSave();
   void autoSavePeriodChanged();
+  void fillOnlySaveboxChanged(bool enabled);
 
 private:
   std::unique_ptr<QSettings> m_settings;

--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -1985,7 +1985,8 @@ FillTool::FillTool(int targetType)
     , m_firstTime(true)
     , m_autopaintLines("Autopaint Lines", true)
     , m_referFill("Refer Fill", false)
-    , m_extendFill("Extend Fill", true) {
+    , m_extendFill("Extend Fill", true)
+    , m_fillOnlySavebox("Savebox", false) {
   m_areaFillTool       = new AreaFillTool(this);
   m_normalLineFillTool = new NormalLineFillTool(this);
 
@@ -2019,6 +2020,7 @@ FillTool::FillTool(int targetType)
     m_prop.bind(m_autopaintLines);
     m_prop.bind(m_extendFill);
     m_prop.bind(m_gapCloseDistance);
+    m_prop.bind(m_fillOnlySavebox);
   }
   m_emptyOnly.setId("EmptyOnly");
   m_onion.setId("OnionSkin");
@@ -2031,6 +2033,7 @@ FillTool::FillTool(int targetType)
   m_autopaintLines.setId("AutopaintLines");
   m_gapCloseDistance.setId("GapCloseDistance");
   m_extendFill.setId("ExtendFill");
+  m_fillOnlySavebox.setId("FillOnlySavebox");
 }
 //-----------------------------------------------------------------------------
 
@@ -2202,6 +2205,7 @@ void FillTool::updateTranslation() {
   m_autopaintLines.setQStringName(tr("Autopaint Lines"));
   m_gapCloseDistance.setQStringName(tr("Gap Close Distance:"));
   m_extendFill.setQStringName(tr("Extend Fill"));
+  m_fillOnlySavebox.setQStringName(tr("Savebox"));
 }
 
 //-----------------------------------------------------------------------------
@@ -2498,6 +2502,14 @@ bool FillTool::onPropertyChanged(std::string propertyName, bool addToUndo) {
     FillExtend = (int)(m_extendFill.getValue());
   }
 
+  else if (propertyName == m_fillOnlySavebox.getName()) {
+    Preferences *preferences = Preferences::instance();
+    bool enabled             = m_fillOnlySavebox.getValue();
+    if (preferences->getFillOnlySavebox() != enabled)
+      preferences->setValue(PreferencesItemId::FillOnlysavebox, enabled);
+    invalidate();
+  }
+
   else if (!m_frameSwitched && (propertyName == m_maxGapDistance.getName())) {
     TXshLevel *xl = TTool::getApplication()->getCurrentLevel()->getLevel();
     m_level       = xl ? xl->getSimpleLevel() : 0;
@@ -2601,7 +2613,8 @@ void FillTool::draw() {
     if (ti) {
       TRectD bbox =
           ToonzImageUtils::convertRasterToWorld(convert(ti->getBBox()), ti);
-      drawRect(bbox * ti->getSubsampling(), TPixel32::Black, 0x5555, true);
+      drawRect(bbox * ti->getSubsampling(), TPixel32(210, 210, 210), 0xF0F0,
+               true);
     }
   }
   if (m_fillType.getValue() != NORMALFILL) {
@@ -2729,6 +2742,22 @@ void FillTool::onActivate() {
   for (i=0; i<osMask.getFosCount(); i++)
   boh = osMask.getFos(i);
   */
+  if (m_targetType == TTool::ToonzImage && !m_saveboxSignalConnected) {
+    connect(Preferences::instance(), &Preferences::fillOnlySaveboxChanged, this,
+            [this](bool enabled) {
+              if (m_fillOnlySavebox.getValue() == enabled) return;
+              m_fillOnlySavebox.setValue(enabled);
+              TTool::Application *app = TTool::getApplication();
+              if (!app || !app->getCurrentTool() ||
+                  app->getCurrentTool()->getTool() != this)
+                return;
+              app->getCurrentTool()->notifyToolChanged();
+              invalidate();
+            });
+    m_saveboxSignalConnected = true;
+  }
+  m_fillOnlySavebox.setValue(Preferences::instance()->getFillOnlySavebox());
+
   if (m_firstTime) {
     m_fillDepth.setValue(
         TDoublePairProperty::Value(MinFillDepth, MaxFillDepth));

--- a/toonz/sources/tnztools/filltool.h
+++ b/toonz/sources/tnztools/filltool.h
@@ -121,12 +121,14 @@ class FillTool final : public QObject, public TTool {
   // disabled
   TBoolProperty m_autopaintLines;
   TBoolProperty m_extendFill;
+  TBoolProperty m_fillOnlySavebox;
 
   SlFidsPairs m_slFidsPairs;
   RefImgTable m_refImgTable;  // imageId
 
   bool m_isAltPressed = false;
   bool m_restoreEmptyOnly;
+  bool m_saveboxSignalConnected = false;
 
 public:
   FillTool(int targetType);

--- a/toonz/sources/tnztools/rastererasertool.cpp
+++ b/toonz/sources/tnztools/rastererasertool.cpp
@@ -28,6 +28,7 @@
 #include "toonz/tobjecthandle.h"
 #include "toonz/tcolumnhandle.h"
 #include "toonz/preferences.h"
+#include "toonz/fill.h"
 
 // TnzBase includes
 #include "tenv.h"
@@ -50,7 +51,12 @@
 
 // Qt includes
 #include <QCoreApplication>  // For Qt translation support
+#include <QMetaObject>
 #include <QPainter>
+
+#include <algorithm>
+#include <cmath>
+#include <set>
 
 using namespace ToolUtils;
 
@@ -62,6 +68,7 @@ using namespace ToolUtils;
 #define RECTERASE L"Rectangular"
 #define FREEHANDERASE L"Freehand"
 #define POLYLINEERASE L"Polyline"
+#define SEGMENTERASE L"Segment"
 
 TEnv::DoubleVar EraseSize("InknpaintEraseSize", 10);
 TEnv::StringVar EraseType("InknpaintEraseType", "Normal");
@@ -266,6 +273,212 @@ public:
   int getHistoryType() override { return HistoryType::EraserTool; }
 };
 
+struct SegmentEraseOptions {
+  TXshSimpleLevel *level;
+  TFrameId frameId;
+  int styleId;
+  bool selective;
+  bool saveboxOnly;
+};
+
+struct SegmentEraseRecord {
+  std::vector<TPoint> points;
+  TRect limitRect;
+  TRect oldSavebox;
+  TRect newSavebox;
+};
+
+struct SegmentFrameTarget {
+  TFrameId frameId;
+  TToonzImageP image;
+};
+
+class RasterSegmentEraseUndo final : public TRasterUndo {
+  SegmentEraseRecord m_record;
+  bool m_saveboxOnly;
+
+public:
+  RasterSegmentEraseUndo(TTileSetCM32 *tileSet,
+                         const SegmentEraseRecord &record,
+                         const SegmentEraseOptions &options)
+      : TRasterUndo(tileSet, options.level, options.frameId, false, false, 0,
+                    false)
+      , m_record(record)
+      , m_saveboxOnly(options.saveboxOnly) {}
+
+  void undo() const override {
+    TTool::Application *app = TTool::getApplication();
+    TToonzImageP image      = getImage();
+    if (!app || !image || !m_tiles || m_tiles->getTileCount() == 0) return;
+
+    ToonzImageUtils::paste(image, m_tiles);
+    image->setSavebox(m_record.oldSavebox);
+    removeLevelAndFrameIfNeeded();
+    if (m_level) m_level->setDirtyFlag(true);
+    app->getCurrentXsheet()->notifyXsheetChanged();
+    notifyImageChanged();
+  }
+
+  void redo() const override {
+    TToonzImageP image = getImage();
+    if (!image) return;
+
+    TRasterCM32P raster = image->getRaster();
+    if (m_saveboxOnly) {
+      TRect limit = m_record.limitRect * raster->getBounds();
+      if (limit.isEmpty()) return;
+      raster = raster->extract(limit);
+    }
+
+    for (const TPoint &point : m_record.points) {
+      if (!raster->getBounds().contains(point)) continue;
+      inkSegment(raster, point, 0, 2.51, true, nullptr, true);
+    }
+
+    image->setSavebox(m_record.newSavebox);
+    if (m_level) m_level->setDirtyFlag(true);
+    TTool::Application *app = TTool::getApplication();
+    if (!app) return;
+    app->getCurrentXsheet()->notifyXsheetChanged();
+    notifyImageChanged();
+  }
+
+  int getSize() const override {
+    return sizeof(*this) + TRasterUndo::getSize() +
+           m_record.points.capacity() * sizeof(TPoint);
+  }
+
+  QString getToolName() override {
+    return QString("Eraser Tool (Segment)");
+  }
+  int getHistoryType() override { return HistoryType::EraserTool; }
+};
+
+TPoint worldToRasterPoint(const TToonzImageP &image, const TPointD &position) {
+  TDimension size = image->getSize();
+  TPointD pixelOffset(size.lx % 2 ? 0.0 : 0.5,
+                      size.ly % 2 ? 0.0 : 0.5);
+  TPointD point = position - pixelOffset;
+  return TPoint((int)std::floor(point.x + 0.5),
+                (int)std::floor(point.y + 0.5)) +
+         image->getRaster()->getCenter();
+}
+
+TRasterCM32P segmentRaster(const TToonzImageP &image, const TRect &limitRect,
+                           bool saveboxOnly) {
+  if (!saveboxOnly) return image->getRaster();
+  TRect extractionRect = limitRect;
+  return image->getRaster()->extract(extractionRect);
+}
+
+bool canEraseSegment(const TPixelCM32 &pixel,
+                     const SegmentEraseOptions &options) {
+  if (pixel.isPurePaint()) return false;
+  return !options.selective || pixel.getInk() == options.styleId;
+}
+
+std::vector<TPoint> eraseSegmentSamples(const TToonzImageP &image,
+                                        const TStroke &stroke,
+                                        const SegmentEraseOptions &options,
+                                        const TRect &limitRect,
+                                        TTileSaverCM32 &tileSaver) {
+  TRasterCM32P raster = segmentRaster(image, limitRect, options.saveboxOnly);
+  TPoint offset = options.saveboxOnly ? limitRect.getP00() : TPoint();
+  std::vector<TPoint> changedPoints;
+  std::set<std::pair<int, int>> visited;
+  double length = stroke.getLength();
+  int steps     = std::max(1, (int)std::ceil(length));
+
+  for (int i = 0; i <= steps; ++i) {
+    double distance = length * i / steps;
+    TPoint point = worldToRasterPoint(image, stroke.getPointAtLength(distance));
+    if (!limitRect.contains(point)) continue;
+
+    TPoint localPoint = point - offset;
+    if (!visited.insert({localPoint.x, localPoint.y}).second) continue;
+    if (!canEraseSegment(raster->pixels(localPoint.y)[localPoint.x], options))
+      continue;
+    if (inkSegment(raster, localPoint, 0, 2.51, true, &tileSaver, true))
+      changedPoints.push_back(localPoint);
+  }
+  return changedPoints;
+}
+
+void offsetSegmentTiles(TTileSetCM32 *tileSet, const TPoint &offset) {
+  if (offset == TPoint()) return;
+  for (int i = 0; i < tileSet->getTileCount(); ++i) {
+    TTileSet::Tile *tile = tileSet->editTile(i);
+    tile->m_rasterBounds = tile->m_rasterBounds + offset;
+  }
+}
+
+bool eraseSegmentsAlongStroke(const TToonzImageP &image, const TStroke &stroke,
+                              const SegmentEraseOptions &options) {
+  if (!image || !options.level) return false;
+  TRasterCM32P fullRaster = image->getRaster();
+  if (!fullRaster) return false;
+
+  SegmentEraseRecord record;
+  record.oldSavebox = image->getSavebox();
+  record.limitRect  = options.saveboxOnly
+                          ? record.oldSavebox * fullRaster->getBounds()
+                          : fullRaster->getBounds();
+  if (record.limitRect.isEmpty()) return false;
+
+  TPoint offset      = options.saveboxOnly ? record.limitRect.getP00()
+                                           : TPoint();
+  TRasterCM32P raster = segmentRaster(image, record.limitRect,
+                                      options.saveboxOnly);
+  auto *tileSet = new TTileSetCM32(raster->getSize());
+  {
+    TTileSaverCM32 tileSaver(raster, tileSet);
+    record.points =
+        eraseSegmentSamples(image, stroke, options, record.limitRect, tileSaver);
+  }
+
+  if (record.points.empty()) {
+    delete tileSet;
+    return false;
+  }
+
+  offsetSegmentTiles(tileSet, offset);
+  options.level->setDirtyFlag(true);
+  ToolUtils::updateSaveBox(options.level, options.frameId);
+  record.newSavebox = image->getSavebox();
+  TUndoManager::manager()->add(
+      new RasterSegmentEraseUndo(tileSet, record, options));
+  return true;
+}
+
+TVectorImageP makeStrokeImage(const TStroke *stroke) {
+  if (!stroke) return TVectorImageP();
+  TVectorImageP image = new TVectorImage();
+  image->addStroke(new TStroke(*stroke));
+  return image;
+}
+
+bool eraseSegmentFrame(const TToonzImageP &image, double progress,
+                       const SegmentEraseOptions &options,
+                       const TVectorImageP &firstImage,
+                       const TVectorImageP &lastImage) {
+  if (!image || !firstImage || !lastImage ||
+      firstImage->getStrokeCount() != 1 || lastImage->getStrokeCount() != 1)
+    return false;
+
+  TVectorImageP tweenImage;
+  TStroke *stroke = nullptr;
+  if (progress == 0.0)
+    stroke = firstImage->getStroke(0);
+  else if (progress == 1.0)
+    stroke = lastImage->getStroke(0);
+  else {
+    tweenImage = TInbetween(firstImage, lastImage).tween(progress);
+    if (tweenImage && tweenImage->getStrokeCount() == 1)
+      stroke = tweenImage->getStroke(0);
+  }
+  return stroke && eraseSegmentsAlongStroke(image, *stroke, options);
+}
+
 void eraseStroke(const TToonzImageP &ti, TStroke *stroke,
                  std::wstring eraseType, std::wstring colorType, bool invert,
                  bool selective, bool pencil, int styleId,
@@ -449,6 +662,7 @@ class EraserTool final : public TTool {
 public:
   EraserTool(std::string name);
   ~EraserTool() {
+    QObject::disconnect(m_saveboxPreferenceConnection);
     if (m_firstStroke) delete m_firstStroke;
   }
 
@@ -501,6 +715,13 @@ public:
 private:
   /*-- Finalization process --*/
   void storeUndoAndRefresh();
+  void multiAreaSegmentEraserByRows(const TXshSimpleLevelP &sl, int firstRow,
+                                    int lastRow, TStroke *firstStroke,
+                                    TStroke *lastStroke);
+  void eraseSegmentFrameRange(
+      const TXshSimpleLevelP &sl,
+      const std::vector<SegmentFrameTarget> &targets, bool backward,
+      const TVectorImageP &firstImage, const TVectorImageP &lastImage);
 
   enum Type { NONE = 0, BRUSH, INKCHANGE, ERASER };
 
@@ -515,6 +736,7 @@ private:
   TBoolProperty m_multi;
   TBoolProperty m_pencil;
   TEnumProperty m_colorType;
+  TBoolProperty m_eraseOnlySavebox;
 
   Type m_type;
 
@@ -522,6 +744,7 @@ private:
   std::pair<int, int> m_currCell;
 
   TFrameId m_firstFrameId, m_veryFirstFrameId;
+  int m_firstSceneRow;
 
   StrokeGenerator m_track;
 
@@ -558,6 +781,7 @@ private:
   /*--- If mouse button Down → property change → mouse button Up occurs,
         do not process since the Down to Up sequence wasn't straight ---*/
   bool m_isLeftButtonPressed;
+  QMetaObject::Connection m_saveboxPreferenceConnection;
 };
 
 EraserTool inkPaintEraserTool("T_Eraser");
@@ -578,7 +802,9 @@ EraserTool::EraserTool(std::string name)
     , m_invertOption("Invert", false)     // W_ToolOptions_Invert
     , m_multi("Frame Range", false)       // W_ToolOptions_FrameRange
     , m_pencil("Pencil Mode", false)
+    , m_eraseOnlySavebox("Savebox", false)
     , m_currCell(-1, -1)
+    , m_firstSceneRow(-1)
     , m_tileSaver(nullptr)
     , m_bluredBrush(nullptr)
     , m_normalEraser(nullptr)
@@ -604,6 +830,7 @@ EraserTool::EraserTool(std::string name)
   m_eraseType.addValue(RECTERASE);
   m_eraseType.addValue(FREEHANDERASE);
   m_eraseType.addValue(POLYLINEERASE);
+  m_eraseType.addValue(SEGMENTERASE);
 
   m_colorType.addValue(LINES);
   m_colorType.addValue(AREAS);
@@ -614,6 +841,7 @@ EraserTool::EraserTool(std::string name)
   m_prop.bind(m_invertOption);
   m_prop.bind(m_multi);
   m_prop.bind(m_pencil);
+  m_prop.bind(m_eraseOnlySavebox);
 
   m_currentStyle.setId("Selective");
   m_invertOption.setId("Invert");
@@ -621,6 +849,7 @@ EraserTool::EraserTool(std::string name)
   m_pencil.setId("PencilMode");
   m_colorType.setId("Mode");
   m_eraseType.setId("Type");
+  m_eraseOnlySavebox.setId("EraseOnlySavebox");
 }
 
 //------------------------------------------------------------------------
@@ -634,6 +863,7 @@ void EraserTool::updateTranslation() {
   m_eraseType.setItemUIName(RECTERASE, tr("Rectangular"));
   m_eraseType.setItemUIName(FREEHANDERASE, tr("Freehand"));
   m_eraseType.setItemUIName(POLYLINEERASE, tr("Polyline"));
+  m_eraseType.setItemUIName(SEGMENTERASE, tr("Segment"));
 
   m_colorType.setQStringName(tr("Mode:"));
   m_colorType.setItemUIName(LINES, tr("Lines"));
@@ -644,6 +874,7 @@ void EraserTool::updateTranslation() {
   m_invertOption.setQStringName(tr("Invert"));
   m_multi.setQStringName(tr("Frame Range"));
   m_pencil.setQStringName(tr("Pencil Mode"));
+  m_eraseOnlySavebox.setQStringName(tr("Savebox"));
 }
 
 //-------------------------------------------------------------------------------------------------------
@@ -679,6 +910,17 @@ TPointD EraserTool::fixMousePos(TPointD pos, bool precise) {
 //------------------------------------------------------------------------
 
 void EraserTool::draw() {
+  if (m_eraseType.getValue() == SEGMENTERASE &&
+      Preferences::instance()->getFillOnlySavebox()) {
+    TToonzImageP image = (TToonzImageP)getImage(false);
+    if (image && !image->getBBox().isEmpty()) {
+      TRectD bbox = ToonzImageUtils::convertRasterToWorld(
+          convert(image->getBBox()), image);
+      drawRect(bbox * image->getSubsampling(), TPixel32(210, 210, 210), 0xF0F0,
+               true);
+    }
+  }
+
   /*-- Prevent red dot from being drawn during MouseLeave --*/
   if (m_pointSize == -1 && m_cleanerSize == 0) return;
 
@@ -718,7 +960,8 @@ void EraserTool::draw() {
                     lx % 2 == 0, ly % 2 == 0);
   }
   if ((m_eraseType.getValue() == FREEHANDERASE ||
-       m_eraseType.getValue() == POLYLINEERASE) &&
+       m_eraseType.getValue() == POLYLINEERASE ||
+       m_eraseType.getValue() == SEGMENTERASE) &&
       m_multi.getValue()) {
     TPixel color = TPixel32::Red;
     tglColor(color);
@@ -732,7 +975,9 @@ void EraserTool::draw() {
     for (UINT i = 0; i < m_polyline.size(); i++) tglVertex(m_polyline[i]);
     tglVertex(m_mousePos);
     glEnd();
-  } else if (m_eraseType.getValue() == FREEHANDERASE && !m_track.isEmpty()) {
+  } else if ((m_eraseType.getValue() == FREEHANDERASE ||
+              m_eraseType.getValue() == SEGMENTERASE) &&
+             !m_track.isEmpty()) {
     TPixel color = ToonzCheck::instance()->getChecks() & ToonzCheck::eBlackBg
                        ? TPixel32::White
                        : TPixel32::Black;
@@ -760,10 +1005,12 @@ int EraserTool::getCursorId() const {
       ret = ret | ToolCursor::Ex_Rectangle;
   }
 
-  if (m_colorType.getValue() == LINES)
-    ret = ret | ToolCursor::Ex_Line;
-  else if (m_colorType.getValue() == AREAS)
-    ret = ret | ToolCursor::Ex_Area;
+  if (m_eraseType.getValue() != SEGMENTERASE) {
+    if (m_colorType.getValue() == LINES)
+      ret = ret | ToolCursor::Ex_Line;
+    else if (m_colorType.getValue() == AREAS)
+      ret = ret | ToolCursor::Ex_Area;
+  }
 
   if (ToonzCheck::instance()->getChecks() & ToonzCheck::eBlackBg)
     ret = ret | ToolCursor::Ex_Negate;
@@ -781,7 +1028,8 @@ void EraserTool::resetMulti() {
   m_level                 = app->getCurrentLevel()->getLevel()
                                 ? app->getCurrentLevel()->getSimpleLevel()
                                 : 0;
-  m_firstFrameId = m_veryFirstFrameId = getFrameId();
+  m_firstFrameId  = m_veryFirstFrameId = getFrameId();
+  m_firstSceneRow = getFrame();
   if (m_firstStroke) {
     delete m_firstStroke;
     m_firstStroke = nullptr;
@@ -965,7 +1213,8 @@ void EraserTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
       m_workingFrameId = getFrameId();
     }
     if (m_eraseType.getValue() == FREEHANDERASE ||
-        m_eraseType.getValue() == POLYLINEERASE) {
+        m_eraseType.getValue() == POLYLINEERASE ||
+        m_eraseType.getValue() == SEGMENTERASE) {
       int col   = getColumnIndex();
       m_enabled = col >= 0;
 
@@ -1105,7 +1354,8 @@ void EraserTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
       }
       invalidate(invalidateRect.enlarge(2) - rasCenter);
     }
-    if (m_eraseType.getValue() == FREEHANDERASE) {
+    if (m_eraseType.getValue() == FREEHANDERASE ||
+        m_eraseType.getValue() == SEGMENTERASE) {
       if (!m_enabled || !m_active) return;
       m_track.add(TThickPoint(pos, m_thick), pixelSize2);
       invalidate(m_track.getModifiedRegion());
@@ -1122,16 +1372,27 @@ void EraserTool::onImageChanged() {
   if (app->getCurrentLevel()->getLevel())
     xshl = app->getCurrentLevel()->getSimpleLevel();
 
-  if (!xshl || m_level.getPointer() != xshl ||
-      (m_selectingRect.isEmpty() && !m_firstStroke))
+  bool editingScene = app->getCurrentFrame()->isEditingScene();
+  bool editingModeChanged =
+      m_firstStroke && m_isXsheetCell != editingScene;
+  bool columnChanged =
+      m_isXsheetCell && m_currCell.first != getColumnIndex();
+  bool isInitialFrame =
+      m_eraseType.getValue() == SEGMENTERASE && m_isXsheetCell
+          ? m_firstSceneRow == getFrame()
+          : m_firstFrameId == getFrameId();
+
+  if (!xshl || m_level.getPointer() != xshl || editingModeChanged ||
+      columnChanged || (m_selectingRect.isEmpty() && !m_firstStroke))
     resetMulti();
-  else if (m_firstFrameId == getFrameId())
+  else if (isInitialFrame)
     m_firstFrameSelected = false;  // If we move to state 1 and return to the
                                    // initial image, return to initial state
   else {                           // Change state.
     m_firstFrameSelected = true;
     if (m_eraseType.getValue() != FREEHANDERASE &&
-        m_eraseType.getValue() != POLYLINEERASE) {
+        m_eraseType.getValue() != POLYLINEERASE &&
+        m_eraseType.getValue() != SEGMENTERASE) {
       assert(!m_selectingRect.isEmpty());
       m_firstRect = m_selectingRect;
     }
@@ -1148,6 +1409,7 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
   if (!m_selecting) return;
   TImageP image(getImage(true));
   if (TToonzImageP ti = image) {
+    bool updateSavebox = true;
     if (m_eraseType.getValue() == RECTERASE) {
       if (m_selectingRect.x0 > m_selectingRect.x1)
         std::swap(m_selectingRect.x1, m_selectingRect.x0);
@@ -1277,17 +1539,24 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
       /*-- Reset working frame --*/
       m_workingFrameId = TFrameId();
     }
-    if (m_eraseType.getValue() == FREEHANDERASE) {
+    if (m_eraseType.getValue() == FREEHANDERASE ||
+        m_eraseType.getValue() == SEGMENTERASE) {
+      bool isSegment = m_eraseType.getValue() == SEGMENTERASE;
+      if (isSegment) updateSavebox = false;
       bool isValid = m_enabled && m_active;
       m_enabled = m_active = false;
       if (!isValid) return;
       if (m_track.isEmpty()) return;
       double pixelSize2 = getPixelSize() * getPixelSize();
-      m_track.add(TThickPoint(m_firstPos, m_thick), pixelSize2);
+      if (isSegment)
+        m_track.add(TThickPoint(pos, m_thick), 0);
+      else
+        m_track.add(TThickPoint(m_firstPos, m_thick), pixelSize2);
       m_track.filterPoints();
       double error    = (30.0 / 11) * sqrt(pixelSize2);
       TStroke *stroke = m_track.makeStroke(error);
 
+      if (!stroke) return;
       stroke->setStyle(1);
       m_track.clear();
 
@@ -1297,10 +1566,15 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
       {
         if (m_firstFrameSelected) {
           TFrameId tmp = getFrameId();
-          if (m_firstStroke && stroke)
-            multiAreaEraser(m_level, m_firstFrameId, tmp, m_firstStroke,
-                            stroke);
-          notifyImageChanged();
+          if (m_firstStroke && stroke) {
+            if (isSegment && m_isXsheetCell)
+              multiAreaSegmentEraserByRows(m_level, m_firstSceneRow,
+                                           getFrame(), m_firstStroke, stroke);
+            else
+              multiAreaEraser(m_level, m_firstFrameId, tmp, m_firstStroke,
+                              stroke);
+          }
+          if (!isSegment) notifyImageChanged();
           if (e.isShiftPressed()) {
             TRectD invalidateRect;
             if (m_firstStroke) {
@@ -1312,7 +1586,8 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
             m_firstStroke  = stroke;
             invalidateRect = m_firstStroke->getBBox();
             invalidate(invalidateRect.enlarge(2));
-            m_firstFrameId = getFrameId();
+            m_firstFrameId  = getFrameId();
+            m_firstSceneRow = getFrame();
           } else {
             if (m_isXsheetCell) {
               app->getCurrentColumn()->setColumnIndex(m_currCell.first);
@@ -1327,6 +1602,7 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
           m_firstStroke  = stroke;
           m_isXsheetCell = app->getCurrentFrame()->isEditingScene();
           m_currCell     = std::pair<int, int>(getColumnIndex(), getFrame());
+          m_firstSceneRow = getFrame();
           invalidate(m_firstStroke->getBBox().enlarge(2));
         }
       } else  // stroke non multi
@@ -1339,19 +1615,34 @@ void EraserTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
         TXshLevel *level          = app->getCurrentLevel()->getLevel();
         TXshSimpleLevelP simLevel = level->getSimpleLevel();
         TFrameId frameId          = getFrameId();
-        eraseStroke(image, stroke, m_eraseType.getValue(),
-                    m_colorType.getValue(), m_invertOption.getValue(),
-                    m_currentStyle.getValue(), m_pencil.getValue(), styleId,
-                    simLevel, frameId);
-        notifyImageChanged();
-        if (m_invertOption.getValue())
-          invalidate();
-        else
-          invalidate(stroke->getBBox().enlarge(2));
+        if (isSegment) {
+          SegmentEraseOptions options{simLevel.getPointer(), frameId, styleId,
+                                      m_currentStyle.getValue(),
+                                      Preferences::instance()
+                                          ->getFillOnlySavebox()};
+          bool changed = eraseSegmentsAlongStroke(ti, *stroke, options);
+          delete stroke;
+          if (changed) {
+            app->getCurrentXsheet()->notifyXsheetChanged();
+            notifyImageChanged(frameId);
+            invalidate();
+          }
+        } else {
+          eraseStroke(image, stroke, m_eraseType.getValue(),
+                      m_colorType.getValue(), m_invertOption.getValue(),
+                      m_currentStyle.getValue(), m_pencil.getValue(), styleId,
+                      simLevel, frameId);
+          notifyImageChanged();
+          if (m_invertOption.getValue())
+            invalidate();
+          else
+            invalidate(stroke->getBBox().enlarge(2));
+          delete stroke;
+        }
       }
     }
 
-    ToolUtils::updateSaveBox();
+    if (updateSavebox) ToolUtils::updateSaveBox();
   }
 
   m_selecting = false;
@@ -1446,6 +1737,7 @@ bool EraserTool::onPropertyChanged(std::string propertyName) {
     if (m_eraseType.getValue() == POLYLINEERASE && !m_polyline.empty())
       m_polyline.clear();
     EraseType = ::to_string(m_eraseType.getValue());
+    invalidate();
   }
 
   else if (propertyName == m_toolSize.getName()) {
@@ -1481,6 +1773,14 @@ bool EraserTool::onPropertyChanged(std::string propertyName) {
     EraseHardness = m_hardness.getValue();
     m_brushPad    = ToolUtils::getBrushPad(m_toolSize.getValue(),
                                            m_hardness.getValue() * 0.01);
+  }
+
+  else if (propertyName == m_eraseOnlySavebox.getName()) {
+    Preferences *preferences = Preferences::instance();
+    bool enabled             = m_eraseOnlySavebox.getValue();
+    if (preferences->getFillOnlySavebox() != enabled)
+      preferences->setValue(PreferencesItemId::FillOnlysavebox, enabled);
+    invalidate();
   }
 
   if (propertyName == m_hardness.getName() ||
@@ -1587,6 +1887,21 @@ void EraserTool::onLeave() {
 //----------------------------------------------------------------------
 
 void EraserTool::onActivate() {
+  if (!m_saveboxPreferenceConnection) {
+    m_saveboxPreferenceConnection = QObject::connect(
+        Preferences::instance(), &Preferences::fillOnlySaveboxChanged,
+        Preferences::instance(), [this](bool enabled) {
+          if (m_eraseOnlySavebox.getValue() == enabled) return;
+          m_eraseOnlySavebox.setValue(enabled);
+          TTool::Application *app = TTool::getApplication();
+          if (!app || !app->getCurrentTool() ||
+              app->getCurrentTool()->getTool() != this)
+            return;
+          app->getCurrentTool()->notifyToolChanged();
+          invalidate();
+        });
+  }
+  m_eraseOnlySavebox.setValue(Preferences::instance()->getFillOnlySavebox());
   if (m_multi.getValue()) resetMulti();
 
   /*-- When entering polyline from another tool, clear previous polyline
@@ -1604,14 +1919,8 @@ void EraserTool::onActivate() {
 void EraserTool::multiAreaEraser(const TXshSimpleLevelP &sl, TFrameId &firstFid,
                                  TFrameId &lastFid, TStroke *firstStroke,
                                  TStroke *lastStroke) {
-  TStroke *first           = new TStroke();
-  TStroke *last            = new TStroke();
-  *first                   = *firstStroke;
-  *last                    = *lastStroke;
-  TVectorImageP firstImage = new TVectorImage();
-  TVectorImageP lastImage  = new TVectorImage();
-  firstImage->addStroke(first);
-  lastImage->addStroke(last);
+  TVectorImageP firstImage = makeStrokeImage(firstStroke);
+  TVectorImageP lastImage  = makeStrokeImage(lastStroke);
 
   bool backward = false;
   if (firstFid > lastFid) {
@@ -1631,17 +1940,90 @@ void EraserTool::multiAreaEraser(const TXshSimpleLevelP &sl, TFrameId &firstFid,
   std::vector<TFrameId> fids(i0, i1);
   int m = fids.size();
   assert(m > 0);
+  bool isSegment = m_eraseType.getValue() == SEGMENTERASE;
+  if (isSegment) {
+    std::vector<SegmentFrameTarget> targets;
+    targets.reserve(fids.size());
+    for (const TFrameId &fid : fids) {
+      TToonzImageP image = sl->getFrame(fid, true);
+      if (image) targets.push_back({fid, image});
+    }
+    eraseSegmentFrameRange(sl, targets, backward, firstImage, lastImage);
+    return;
+  }
+
   TUndoManager::manager()->beginBlock();
   for (int i = 0; i < m; ++i) {
     TFrameId fid = fids[i];
     assert(firstFid <= fid && fid <= lastFid);
     TImageP img = sl->getFrame(fid, true);
-    double t    = m > 1 ? (double)i / (double)(m - 1) : 0.5;
-    doMultiEraser(img, backward ? 1 - t : t, sl, fid, firstImage, lastImage);
+    double t = m > 1 ? (double)i / (double)(m - 1) : 0.5;
+    double progress = backward ? 1 - t : t;
+    doMultiEraser(img, progress, sl, fid, firstImage, lastImage);
     sl->getProperties()->setDirtyFlag(true);
     notifyImageChanged(fid);
   }
   TUndoManager::manager()->endBlock();
+}
+
+//-------------------------------------------------------------------------------------------------
+
+void EraserTool::multiAreaSegmentEraserByRows(
+    const TXshSimpleLevelP &sl, int firstRow, int lastRow,
+    TStroke *firstStroke, TStroke *lastStroke) {
+  bool backward = false;
+  if (firstRow > lastRow) {
+    std::swap(firstRow, lastRow);
+    backward = true;
+  }
+
+  std::vector<SegmentFrameTarget> targets;
+  std::set<TFrameId> seenFrames;
+  TXsheet *xsheet = TTool::getApplication()->getCurrentXsheet()->getXsheet();
+  for (int row = firstRow; row <= lastRow; ++row) {
+    TXshCell cell = xsheet->getCell(row, m_currCell.first);
+    if (cell.isEmpty() || cell.getSimpleLevel() != sl.getPointer()) continue;
+    TFrameId fid = cell.getFrameId();
+    if (!seenFrames.insert(fid).second) continue;
+    TToonzImageP image = (TToonzImageP)cell.getImage(true);
+    if (image) targets.push_back({fid, image});
+  }
+
+  TVectorImageP firstImage = makeStrokeImage(firstStroke);
+  TVectorImageP lastImage  = makeStrokeImage(lastStroke);
+  eraseSegmentFrameRange(sl, targets, backward, firstImage, lastImage);
+}
+
+//-------------------------------------------------------------------------------------------------
+
+void EraserTool::eraseSegmentFrameRange(
+    const TXshSimpleLevelP &sl,
+    const std::vector<SegmentFrameTarget> &targets, bool backward,
+    const TVectorImageP &firstImage, const TVectorImageP &lastImage) {
+  if (targets.empty()) return;
+
+  int styleId      = TTool::getApplication()->getCurrentLevelStyleIndex();
+  bool selective   = m_currentStyle.getValue();
+  bool saveboxOnly = Preferences::instance()->getFillOnlySavebox();
+  bool anyChanged  = false;
+  TUndoManager::manager()->beginBlock();
+  for (int i = 0; i < (int)targets.size(); ++i) {
+    const SegmentFrameTarget &target = targets[i];
+    double t = targets.size() > 1
+                   ? (double)i / (double)(targets.size() - 1)
+                   : 0.5;
+    SegmentEraseOptions options{sl.getPointer(), target.frameId, styleId,
+                                selective, saveboxOnly};
+    bool changed = eraseSegmentFrame(target.image, backward ? 1 - t : t,
+                                     options, firstImage, lastImage);
+    if (!changed) continue;
+    sl->getProperties()->setDirtyFlag(true);
+    notifyImageChanged(target.frameId);
+    anyChanged = true;
+  }
+  TUndoManager::manager()->endBlock();
+  if (anyChanged)
+    TTool::getApplication()->getCurrentXsheet()->notifyXsheetChanged();
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/toonz/sources/tnztools/setsaveboxtool.cpp
+++ b/toonz/sources/tnztools/setsaveboxtool.cpp
@@ -221,8 +221,8 @@ void SetSaveboxTool::draw() {
   else
     bbox = m_modifiedRect;
 
-  drawRect(bbox * image->getSubsampling(), TPixel32::Black, 0x5555, true);
-  tglColor(TPixel32(90, 90, 90));
+  bbox *= image->getSubsampling();
+  drawRect(bbox, TPixel32(210, 210, 210), 0xF0F0, true);
 
   double pixelSize = m_tool->getPixelSize();
   TPointD p00      = bbox.getP00();
@@ -233,13 +233,20 @@ void SetSaveboxTool::draw() {
   TPointD p11_10   = (bbox.getP11() + bbox.getP10()) * 0.5;
   TPointD p00_01   = (bbox.getP00() + bbox.getP01()) * 0.5;
   TPointD p00_10   = (bbox.getP00() + bbox.getP10()) * 0.5;
-  TPointD size(pixelSize * 4, pixelSize * 4);
-  tglDrawRect(TRectD(p00 - size, p00 + size));
-  tglDrawRect(TRectD(p11 - size, p11 + size));
-  tglDrawRect(TRectD(p01 - size, p01 + size));
-  tglDrawRect(TRectD(p10 - size, p10 + size));
-  tglDrawRect(TRectD(p11_01 - size, p11_01 + size));
-  tglDrawRect(TRectD(p11_10 - size, p11_10 + size));
-  tglDrawRect(TRectD(p00_01 - size, p00_01 + size));
-  tglDrawRect(TRectD(p00_10 - size, p00_10 + size));
+  TPixel32 frameColor(210, 210, 210);
+  TPixel32 shadowColor(0, 0, 0);
+  auto drawHandle = [&](const TPointD &point) {
+    drawSquare(point + TPointD(-pixelSize, pixelSize), pixelSize * 4,
+               frameColor);
+    drawSquare(point, pixelSize * 4, shadowColor);
+  };
+
+  drawHandle(p00);
+  drawHandle(p11);
+  drawHandle(p01);
+  drawHandle(p10);
+  drawHandle(p11_01);
+  drawHandle(p11_10);
+  drawHandle(p00_01);
+  drawHandle(p00_10);
 }

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -2132,7 +2132,16 @@ void BrushToolOptionsBox::onRemovePreset() {
 EraserToolOptionsBox::EraserToolOptionsBox(QWidget *parent, TTool *tool,
                                            TPaletteHandle *pltHandle,
                                            ToolHandle *toolHandle)
-    : ToolOptionsBox(parent), m_pencilMode(0), m_colorMode(0) {
+    : ToolOptionsBox(parent)
+    , m_pencilMode(nullptr)
+    , m_invertMode(nullptr)
+    , m_multiFrameMode(nullptr)
+    , m_eraseOnlySavebox(nullptr)
+    , m_toolType(nullptr)
+    , m_colorMode(nullptr)
+    , m_hardnessLabel(nullptr)
+    , m_colorModeLabel(nullptr)
+    , m_hardnessField(nullptr) {
   TPropertyGroup *props = tool->getProperties(0);
   assert(props->getPropertyCount() > 0);
 
@@ -2147,11 +2156,15 @@ EraserToolOptionsBox::EraserToolOptionsBox(QWidget *parent, TTool *tool,
   if (m_hardnessField)
     m_hardnessLabel = m_labels.value(m_hardnessField->propertyName());
   m_colorMode  = dynamic_cast<ToolOptionCombo *>(m_controls.value("Mode:"));
+  if (m_colorMode)
+    m_colorModeLabel = m_labels.value(m_colorMode->propertyName());
   m_invertMode = dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Invert"));
   m_multiFrameMode =
       dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Frame Range"));
   m_pencilMode =
       dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Pencil Mode"));
+  m_eraseOnlySavebox =
+      dynamic_cast<ToolOptionCheckbox *>(m_controls.value("Savebox"));
 
   bool ret = true;
   if (m_pencilMode) {
@@ -2174,6 +2187,13 @@ EraserToolOptionsBox::EraserToolOptionsBox(QWidget *parent, TTool *tool,
     m_invertMode->setEnabled(false);
     m_multiFrameMode->setEnabled(false);
   }
+
+  bool isSegment =
+      m_toolType && m_toolType->getProperty()->getValue() == L"Segment";
+  if (m_colorMode) m_colorMode->setDisabled(isSegment);
+  if (m_colorModeLabel) m_colorModeLabel->setDisabled(isSegment);
+  if (isSegment && m_invertMode) m_invertMode->setEnabled(false);
+  if (m_eraseOnlySavebox) m_eraseOnlySavebox->setEnabled(isSegment);
 
   if (m_colorMode && m_colorMode->getProperty()->getValue() == L"Areas") {
     assert(m_hardnessField && m_hardnessLabel && m_pencilMode);
@@ -2205,8 +2225,12 @@ void EraserToolOptionsBox::onPencilModeToggled(bool value) {
 void EraserToolOptionsBox::onToolTypeChanged(int index) {
   const TEnumProperty::Range &range = m_toolType->getProperty()->getRange();
   bool value                        = range[index] != L"Normal";
-  m_invertMode->setEnabled(value);
+  bool isSegment                    = range[index] == L"Segment";
+  m_invertMode->setEnabled(value && !isSegment);
   m_multiFrameMode->setEnabled(value);
+  if (m_colorMode) m_colorMode->setDisabled(isSegment);
+  if (m_colorModeLabel) m_colorModeLabel->setDisabled(isSegment);
+  if (m_eraseOnlySavebox) m_eraseOnlySavebox->setEnabled(isSegment);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -59,6 +59,7 @@
 #include <QListWidget>
 #include <QGroupBox>
 #include <QKeySequence>
+#include <QSignalBlocker>
 
 using namespace DVGui;
 
@@ -1354,7 +1355,8 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       // Tools
       // {dropdownShortcutsCycleOptions, tr("Dropdown Shortcuts:")}, //
       // removed
-      {FillOnlysavebox, tr("Use the TLV Savebox to Limit Filling Operations")},
+      {FillOnlysavebox,
+       tr("Use the TLV Savebox to Limit Fill and Segment Eraser Operations")},
       {DefRegionWithPaint,
        tr("Define Filling Region Using both Lines and Areas")},
       {ReferFillPrevailing, tr("Paint Under Lines in Refer Fill")},
@@ -1683,6 +1685,13 @@ PreferencesPopup::PreferencesPopup()
 
   connect(categoryList, &QListWidget::currentRowChanged, stackedWidget,
           &QStackedWidget::setCurrentIndex);
+  connect(m_pref, &Preferences::fillOnlySaveboxChanged, this,
+          [this](bool enabled) {
+            CheckBox *saveboxCheck = getUI<CheckBox *>(FillOnlysavebox);
+            if (!saveboxCheck || saveboxCheck->isChecked() == enabled) return;
+            QSignalBlocker blocker(saveboxCheck);
+            saveboxCheck->setChecked(enabled);
+          });
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonzlib/fillutil.cpp
+++ b/toonz/sources/toonzlib/fillutil.cpp
@@ -12,6 +12,7 @@
 #include "tpixelutils.h"
 #include "tropcm.h"
 #include "tenv.h"
+#include <cstdlib>
 #include <stack>
 
 #include "toonz/preferences.h"
@@ -652,6 +653,14 @@ const int damInk = TPixelCM32::getMaxInk() - 1;
 //-----------------------------------------------------------------------------
 
 class InkSegmenter {
+  struct BoundaryPixel {
+    TPoint m_point;
+    TPixelCM32 m_original;
+    bool m_restore;
+  };
+
+  using Boundary = std::vector<BoundaryPixel>;
+
   int m_lx, m_ly, m_wrap;
   int m_displaceVector[8];
   TPixelCM32 *m_buf;
@@ -659,9 +668,12 @@ class InkSegmenter {
   TRasterCM32P m_r;
   TTileSaverCM32 *m_saver;
   float m_growFactor;
+  bool m_clearInk;
+  bool m_clearChanged;
 
 public:
-  InkSegmenter(const TRasterCM32P &r, float growFactor, TTileSaverCM32 *saver)
+  InkSegmenter(const TRasterCM32P &r, float growFactor, TTileSaverCM32 *saver,
+               bool clearInk)
       : m_r(r)
       , m_lx(r->getLx())
       , m_ly(r->getLy())
@@ -669,7 +681,9 @@ public:
       , m_buf((TPixelCM32 *)r->getRawData())
       , m_bBox(r->getBounds())
       , m_saver(saver)
-      , m_growFactor(growFactor) {
+      , m_growFactor(growFactor)
+      , m_clearInk(clearInk)
+      , m_clearChanged(false) {
     m_displaceVector[0] = -m_wrap - 1;
     m_displaceVector[1] = -m_wrap;
     m_displaceVector[2] = -m_wrap + 1;
@@ -701,7 +715,7 @@ public:
     pix = m_buf + p.y * m_wrap + p.x;
 
     /*-- If the same ink is used, RETURN --*/
-    if (pix->getInk() == ink) return false;
+    if (pix->getInk() == ink && !m_clearInk) return false;
 
     if (!ConnectionTable[neighboursCode(pix, p)]) {
       master = slave = pix;
@@ -719,23 +733,43 @@ public:
 
     // vector<pair<TPixelCM32*, int> > oldInks;
 
-    drawSegment(d1p1, d1p2, damInk, m_saver);
-    drawSegment(d2p1, d2p2, damInk, m_saver);
+    Boundary firstBoundary;
+    Boundary secondBoundary;
+    if (m_clearInk) {
+      firstBoundary  = collectBoundary(d1p1, d1p2);
+      secondBoundary = collectBoundary(d2p1, d2p2);
+      markBoundary(firstBoundary);
+      markBoundary(secondBoundary);
+    } else {
+      drawSegment(d1p1, d1p2, damInk, m_saver);
+      drawSegment(d2p1, d2p2, damInk, m_saver);
+    }
 
     inkSegmentFill(p, ink, isSelective, m_saver);
 
     // UINT i;
-
-    drawSegment(d1p1, d1p2, ink, m_saver);
-    drawSegment(d2p1, d2p2, ink, m_saver);
+    if (m_clearInk)
+      finishBoundaries(firstBoundary, secondBoundary, ink);
+    else {
+      drawSegment(d1p1, d1p2, ink, m_saver);
+      drawSegment(d2p1, d2p2, ink, m_saver);
+    }
 
     /*	for (i=0; i<oldInks.size(); i++)
     (oldInks[i].first)->setInk(ink);*/
 
-    return true;
+    return m_clearInk ? m_clearChanged : true;
   }
 
 private:
+  Boundary collectBoundary(const TPoint &p0, const TPoint &p1) const;
+  void markBoundary(const Boundary &boundary);
+  bool boundaryHasConnectedInk(const Boundary &boundary) const;
+  void mergeBoundary(Boundary &merged, const Boundary &boundary,
+                     bool restore) const;
+  void finishBoundaries(const Boundary &first, const Boundary &second, int ink);
+  void clearPixel(TPixelCM32 &pixel, int ink);
+
   void drawSegment(
       const TPoint &p0, const TPoint &p1, int ink,
       /*vector<pair<TPixelCM32*, int> >& oldInks,*/ TTileSaverCM32 *saver);
@@ -794,6 +828,126 @@ private:
             ((n && e) ? ((!nePix(seed)->isPurePaint()) << 7) : 0));
   }
 };
+
+//-----------------------------------------------------------------------------
+
+InkSegmenter::Boundary InkSegmenter::collectBoundary(const TPoint &p0,
+                                                      const TPoint &p1) const {
+  Boundary boundary;
+  int x0 = p0.x;
+  int y0 = p0.y;
+  int x1 = p1.x;
+  int y1 = p1.y;
+  if (x0 > x1) {
+    std::swap(x0, x1);
+    std::swap(y0, y1);
+  }
+
+  const int xDistance = x1 - x0;
+  const int yDistance = std::abs(y1 - y0);
+  const int yStep     = y0 <= y1 ? 1 : -1;
+  const bool xMajor   = yDistance <= xDistance;
+  const int majorSize = xMajor ? xDistance : yDistance;
+  const int minorSize = xMajor ? yDistance : xDistance;
+  int decision        = 2 * minorSize - majorSize;
+  int major = 0;
+  int minor = 0;
+
+  while (major <= majorSize) {
+    const int x = x0 + (xMajor ? major : minor);
+    const int y = y0 + yStep * (xMajor ? minor : major);
+    const TPoint point(x, y);
+    if (m_bBox.contains(point))
+      boundary.push_back({point, m_r->pixels(y)[x], false});
+    if (decision <= 0)
+      decision += 2 * minorSize;
+    else {
+      decision += 2 * (minorSize - majorSize);
+      ++minor;
+    }
+    ++major;
+  }
+
+  return boundary;
+}
+
+//-----------------------------------------------------------------------------
+
+void InkSegmenter::markBoundary(const Boundary &boundary) {
+  for (const BoundaryPixel &boundaryPixel : boundary) {
+    if (m_saver) m_saver->save(boundaryPixel.m_point);
+    m_r->pixels(boundaryPixel.m_point.y)[boundaryPixel.m_point.x].setInk(
+        damInk);
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+bool InkSegmenter::boundaryHasConnectedInk(const Boundary &boundary) const {
+  for (const BoundaryPixel &boundaryPixel : boundary) {
+    for (int y = boundaryPixel.m_point.y - 1;
+         y <= boundaryPixel.m_point.y + 1; ++y) {
+      for (int x = boundaryPixel.m_point.x - 1;
+           x <= boundaryPixel.m_point.x + 1; ++x) {
+        const TPoint neighbor(x, y);
+        if (neighbor == boundaryPixel.m_point || !m_bBox.contains(neighbor))
+          continue;
+        const TPixelCM32 &pixel = m_r->pixels(y)[x];
+        if (pixel.getInk() != damInk && !pixel.isPurePaint()) return true;
+      }
+    }
+  }
+  return false;
+}
+
+//-----------------------------------------------------------------------------
+
+void InkSegmenter::mergeBoundary(Boundary &merged, const Boundary &boundary,
+                                 bool restore) const {
+  for (const BoundaryPixel &boundaryPixel : boundary) {
+    Boundary::iterator found = merged.begin();
+    while (found != merged.end() && found->m_point != boundaryPixel.m_point)
+      ++found;
+
+    if (found == merged.end()) {
+      BoundaryPixel mergedPixel = boundaryPixel;
+      mergedPixel.m_restore      = restore;
+      merged.push_back(mergedPixel);
+    } else if (restore) {
+      found->m_restore = true;
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void InkSegmenter::finishBoundaries(const Boundary &first,
+                                    const Boundary &second, int ink) {
+  Boundary merged;
+  merged.reserve(first.size() + second.size());
+  mergeBoundary(merged, first, boundaryHasConnectedInk(first));
+  mergeBoundary(merged, second, boundaryHasConnectedInk(second));
+
+  for (const BoundaryPixel &boundaryPixel : merged) {
+    TPixelCM32 &pixel =
+        m_r->pixels(boundaryPixel.m_point.y)[boundaryPixel.m_point.x];
+    if (boundaryPixel.m_restore)
+      pixel = boundaryPixel.m_original;
+    else {
+      pixel = boundaryPixel.m_original;
+      clearPixel(pixel, ink);
+    }
+  }
+}
+
+//-----------------------------------------------------------------------------
+
+void InkSegmenter::clearPixel(TPixelCM32 &pixel, int ink) {
+  if (pixel.getInk() != ink || pixel.getTone() != TPixelCM32::getMaxTone())
+    m_clearChanged = true;
+  pixel.setInk(ink);
+  pixel.setTone(TPixelCM32::getMaxTone());
+}
 
 //-----------------------------------------------------------------------------
 
@@ -887,7 +1041,7 @@ void InkSegmenter::inkSegmentFill(const TPoint &p, int ink, bool isSelective,
   TPixelCM32 *pix    = pixels + p.y * m_wrap + x;
   int oldInk;
 
-  if (pix->isPurePaint() || pix->getInk() == ink) return;
+  if (pix->isPurePaint() || (pix->getInk() == ink && !m_clearInk)) return;
 
   if (isSelective) oldInk = pix->getInk();
 
@@ -901,13 +1055,16 @@ void InkSegmenter::inkSegmentFill(const TPoint &p, int ink, bool isSelective,
     x               = seed.x;
     y               = seed.y;
     TPixelCM32 *pix = pixels + (y * m_wrap + x);
-    if (pix->isPurePaint() || pix->getInk() == ink || pix->getInk() == damInk ||
-        (isSelective && pix->getInk() != oldInk))
+    if (pix->isPurePaint() || (pix->getInk() == ink && !m_clearInk) ||
+        pix->getInk() == damInk || (isSelective && pix->getInk() != oldInk))
       continue;
 
     if (saver) saver->save(seed);
 
-    pix->setInk(ink);
+    if (m_clearInk)
+      clearPixel(*pix, ink);
+    else
+      pix->setInk(ink);
 
     if (x > 0) seeds.push(TPoint(x - 1, y));
     if (y > 0) seeds.push(TPoint(x, y - 1));
@@ -1368,9 +1525,10 @@ int InkSegmenter::nextPointIsGoodRev(TPoint mp, TPoint sp, TPixelCM32 *slave,
 //-----------------------------------------------------------------------------
 
 bool inkSegment(const TRasterCM32P &r, const TPoint &p, int ink,
-                float growFactor, bool isSelective, TTileSaverCM32 *saver) {
+                float growFactor, bool isSelective, TTileSaverCM32 *saver,
+                bool clearInk) {
   r->lock();
-  InkSegmenter is(r, growFactor, saver);
+  InkSegmenter is(r, growFactor, saver, clearInk);
   bool ret = is.compute(p, ink, isSelective);
   r->unlock();
   return ret;

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -939,6 +939,7 @@ void Preferences::setValue(const PreferencesItemId id, QVariant value,
                            bool saveToFile) {
   assert(m_items.contains(id));
   if (!m_items.contains(id)) return;
+  bool valueChanged = m_items[id].value != value;
   m_items[id].value = value;
   if (saveToFile) {
     if (m_items[id].type ==
@@ -954,6 +955,8 @@ void Preferences::setValue(const PreferencesItemId id, QVariant value,
 
   // Execute callback
   if (m_items[id].onEditedFunc) (this->*(m_items[id].onEditedFunc))();
+  if (valueChanged && id == FillOnlysavebox)
+    emit fillOnlySaveboxChanged(value.toBool());
 }
 
 //-----------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add Segment mode to the Toonz Raster Eraser, including Selective and Frame Range operation
- use the existing Savebox fill preference as the shared persisted setting for Fill and Segment Eraser controls
- preserve exact saveboxes through undo and redo, and skip undo entries for no-op erases
- traverse scene Frame Ranges by Xsheet row while skipping blank, mixed-level, and repeated held drawings
- improve Savebox overlays and keep autoclose caches separate for limited and full-raster filling

## Upstream credit

Ported and adapted from:
- https://github.com/tahoma2d/tahoma2d/pull/518 by @jeremybullock
- https://github.com/tahoma2d/tahoma2d/pull/738 and its follow-up fixes by @manongjohn

The commits include Co-authored-by trailers for both original developers.

## Validation

- compiled every changed translation unit with the generated CMake commands and warnings treated as errors, excluding existing macOS OpenGL deprecation warnings
- regenerated and compiled the Preferences Qt meta-object source
- passed focused clear-mode, no-op, mixed-style junction, border, boundary-equivalence, and recolor-regression tests
- verified git diff --check

The full local target link remains blocked by the bundled SuperLU archive, which has no arm64 slice.