### PR TITLE
Set Brush as default tool at startup

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -1378,7 +1378,7 @@ void IoCmd::newScene() {
   ToolHandle *toolH = TApp::instance()->getCurrentTool();
   if (toolH && toolH->getTool()) toolH->getTool()->reset();
 
-  CommandManager::instance()->execute("T_Hand");
+  CommandManager::instance()->execute("T_Brush");
 
   CommandManager::instance()->enable(MI_SaveSubxsheetAs, false);
 

--- a/toonz/sources/toonz/main.cpp
+++ b/toonz/sources/toonz/main.cpp
@@ -793,7 +793,7 @@ int main(int argc, char *argv[]) {
   // Show floating panels only after the main window has been shown
   w.startupFloatingPanels();
 
-  CommandManager::instance()->execute(T_Hand);
+  CommandManager::instance()->execute(T_Brush);
   if (!loadFilePath.isEmpty()) {
     splash.showMessage(
         QString("Loading file '") + loadFilePath.getQString() + "'...",


### PR DESCRIPTION
Select the Brush tool by default when OpenToonz starts and when a new scene is created, instead of the Hand tool.

**Note :** this changes the default behavior. It still feels like a reasonable default to me, since most people start by drawing.

This feature was developed with Cursor’s AI models