### PR TITLE
Fix Camera Capture interval and onion skin controls

### DIFF
--- a/toonz/sources/toonz/penciltestpopup.cpp
+++ b/toonz/sources/toonz/penciltestpopup.cpp
@@ -1714,14 +1714,12 @@ PencilTestPopup::PencilTestPopup()
   m_onionSkinGBox->setChecked(false);
   m_onionOpacityFld->setRange(1, 100);
   m_onionOpacityFld->setValue(50);
-  m_onionOpacityFld->setDisabled(true);
 
   m_timerGBox->setObjectName("CleanupSettingsFrame");
   m_timerGBox->setCheckable(true);
   m_timerGBox->setChecked(false);
   m_timerIntervalFld->setRange(0, 60);
   m_timerIntervalFld->setValue(10);
-  m_timerIntervalFld->setDisabled(true);
   // Make the interval timer single-shot. When the capture finished, restart
   // timer for next frame.
   // This is because capturing and saving the image needs some time.


### PR DESCRIPTION
Restores the Camera Capture Interval Timer and Onion Skin opacity controls.

Regression source: opentoonz/opentoonz#4250 (`d9416c96c22781a011f9481ed4a77a16b3672976`) changed the separate Onion Skin / Interval Timer checkboxes into checkable `QGroupBox` controls. During that refactor the toggle handlers stopped explicitly re-enabling the fields, but the constructor-level `setDisabled(true)` calls remained.

This removes those two stale explicit disables so the checkable group boxes control their child fields as intended.