### PR TITLE
Fix macOS scene saving for rotation expressions

### DIFF
--- a/toonz/sources/common/tparam/tdoublekeyframe.cpp
+++ b/toonz/sources/common/tparam/tdoublekeyframe.cpp
@@ -5,6 +5,23 @@
 #include "tconvert.h"
 #include "tunit.h"
 
+namespace {
+
+bool isDegreeUnitName(const std::string &unitName) {
+  // Keep the angle unit platform-neutral in scene files. Depending on the
+  // conversion path, U+00B0 may reach this legacy std::string field as UTF-8,
+  // Latin-1/Windows-1252, or legacy MacRoman. The scene format historically
+  // stores the degree unit as the ASCII escape "\\u00b0".
+  static const std::string degreeUtf8("\xC2\xB0", 2);
+  static const std::string degreeLatin1("\xB0", 1);
+  static const std::string degreeMacRoman("\xA1", 1);
+
+  return unitName == "\\u00b0" || unitName == degreeUtf8 ||
+         unitName == degreeLatin1 || unitName == degreeMacRoman;
+}
+
+}  // namespace
+
 TDoubleKeyframe::TDoubleKeyframe(double frame, double value)
     : m_type(Linear)
     , m_frame(frame)
@@ -54,10 +71,7 @@ void TDoubleKeyframe::saveData(TOStream &os) const {
     break;
   }
   std::string unitName = m_unitName != "" ? m_unitName : "default";
-  // Dirty resolution. Because the degree sign is converted to unexpected
-  // string...
-  if (QString::fromStdWString(L"\u00b0").toStdString() == unitName)
-    unitName = "\\u00b0";
+  if (isDegreeUnitName(unitName)) unitName = "\\u00b0";
   switch (m_type) {
   case Constant:
   case Exponential:


### PR DESCRIPTION
## Summary

Normalizes the degree unit before serializing expression/file interpolation keyframes so rotation expressions keep using OpenToonz's established ASCII `\u00b0` scene-file representation regardless of which legacy byte encoding reached `TDoubleKeyframe::m_unitName`.

This is a narrow test fix for `opentoonz/opentoonz#5313`.

## Background

Issue #5313 reports that on macOS any Expression applied to a column's Rotation parameter prevents the scene from saving, even an expression as simple as `0`. The same supplied project saves successfully on Windows and Linux.

The failure closely matches the older `opentoonz/opentoonz#237`, fixed by `opentoonz/opentoonz#258`, where Rotation + Expression serialization wrote the degree unit incorrectly. That 2016 fix added a Qt string-conversion comparison before writing `\u00b0`.

The current code still relies on that byte-for-byte Qt conversion comparison. This patch replaces it with explicit recognition of the degree unit representations that can reach the legacy `std::string` unit field and always serializes them to the same historical ASCII token.

## Change

One source file:

- `toonz/sources/common/tparam/tdoublekeyframe.cpp`

The serializer recognizes:

- UTF-8 U+00B0
- Latin-1 / Windows-1252 degree byte
- legacy MacRoman degree byte
- the already escaped `\u00b0` form

All are serialized as `\u00b0`.

No changes are made to:

- the expression evaluator
- `vertex()` expressions
- Plastic skeleton/deformation code
- `TStageObject`
- general scene save behavior
- the `.tnz` format

## Why this is testable

The patch deliberately targets serialization only. The expression already evaluates correctly in the reported case; the failure occurs when saving the scene.

### Primary macOS reproduction

1. Create or open a scene with a column.
2. Open the Function Editor / Schematic controls for that column's **Rotation**.
3. Change interpolation to **Expression**.
4. Enter `0` and Apply.
5. Save the scene.
6. Close and reopen the scene.
7. Confirm the scene saves and the Rotation expression remains intact.

### Reporter integration case

Use the reproduction project attached to `opentoonz/opentoonz#5313` and set the head Rotation expression to:

```text
vertex(3, "HEAD").angle
```

Confirm:

- the expression drives the head rotation;
- the scene saves on macOS;
- the saved scene reopens;
- Plastic deformation and driven rotation remain correct after reload.

### Regression checks

- Rotation Expression `0` saves/reopens on Windows.
- Rotation Expression `0` saves/reopens on Linux.
- Position XYZ expressions still save/reopen.
- Scale expressions still save/reopen.
- Ordinary Linear/Constant Rotation keys are unchanged.
- Existing scenes containing angle expressions still load and resave.

## Expected scene serialization

Angle-expression units should continue to use the historical escaped degree token rather than a raw platform-dependent degree byte.

## Status

Draft for CI and, most importantly, macOS functional verification before considering an upstream PR.