### PR TITLE
Fix Guard invalid stage object IDs (BadPegbar)

### DIFF
--- a/toonz/sources/include/toonz/tstageobjectid.h
+++ b/toonz/sources/include/toonz/tstageobjectid.h
@@ -5,6 +5,8 @@
 
 #include "tcommon.h"
 
+#include <cassert>
+
 #undef DVAPI
 #undef DVVAR
 #ifdef TOONZLIB_EXPORTS
@@ -37,7 +39,17 @@ class DVAPI TStageObjectId {
   typedef unsigned int Code;
   Code m_id;
 
-  explicit TStageObjectId(Code id) : m_id(id) {}
+  static bool hasKnownType(Code id) {
+    // Keep this in sync with the persisted StageObjectType values used by
+    // tstageobject.cpp. Unknown type bits would otherwise stringify as
+    // "BadPegbar" and can leak into the stage-object tree in Release builds.
+    Code type = id >> 28;
+    return type == 0 || type == 1 || type == 2 || type == 5 || type == 6;
+  }
+
+  explicit TStageObjectId(Code id) : m_id(hasKnownType(id) ? id : Code(0)) {
+    assert(hasKnownType(id));
+  }
 
 public:
   TStageObjectId();


### PR DESCRIPTION
## Summary

Prevents malformed `TStageObjectId` values created through the normal stage-object factories from propagating into the scene and appearing as `BadPegbar`.

Related upstream issue: opentoonz/opentoonz#2828

## Background / partial existing fix

The original 2019 failure path has already been partially fixed in current OpenToonz.

The older Animate/Edit Tool code effectively did this when the camera pseudo-column was selected:

```cpp
if (index == -1) objId = TStageObjectId::CameraId(0);
objId = TStageObjectId::ColumnId(index);
```

Because there was no `else`, the correct camera ID was immediately overwritten by `ColumnId(-1)`.

Current code now uses the correct `if / else` form, so that original trigger is no longer present. This explains why the issue temporarily appeared resolved even though later reports of `BadPegbar` resurfaced.

The underlying weakness remained: the `CameraId()`, `PegbarId()`, and `ColumnId()` factories rely on `assert()` to validate the index. In Release builds the assertion is removed. Passing `-1` can therefore be bit-packed into `0xFFFFFFFF`; its type bits do not match any valid stage-object type, so `TStageObjectId::toString()` falls through to the diagnostic name `BadPegbar`.

## Change

Add validation to the private encoded-ID constructor used by the standard `TStageObjectId` factories.

- Known stage-object type codes are accepted unchanged.
- In Debug builds, an unknown encoded type still asserts so the originating caller is exposed during development.
- In Release builds, an unknown encoded type is normalized to the `None` code instead of allowing an impossible ID to propagate into the stage-object graph.
- The `BadPegbar` string is intentionally retained as a diagnostic sentinel rather than renamed or hidden.

This puts the defensive check below individual callers, so a future accidental negative index cannot recreate the original `ColumnId(-1)` failure merely because a caller missed a guard.

## Scope note

This staged change intentionally leaves the public raw `setCode()` path unchanged to avoid changing legacy scene/deserialization behavior without separate compatibility testing. The immediate target is malformed IDs produced internally through the standard factory path implicated by #2828.

## Validation

This is staged in OT-Dev for CI and regression testing before considering an upstream PR. Suggested manual regression:

1. Start a new scene.
2. Select the camera column.
3. Use Animate at frame 1 to create a camera keyframe.
4. Create a level in Column 1.
5. Open the Function Editor and inspect the Stage Object tree.
6. Confirm no `BadPegbar` entry is created.

Also exercise Animate/Edit Tool camera-to-column switching and Shift/parent-selection paths, since those are the areas most likely to expose a negative column index.