### PR TITLE
Preserve keyframe state during overwrite moves

### DIFF
--- a/toonz/sources/toonz/keyframedata.cpp
+++ b/toonz/sources/toonz/keyframedata.cpp
@@ -24,6 +24,7 @@ TKeyframeData::TKeyframeData() {}
 
 TKeyframeData::TKeyframeData(const TKeyframeData *src)
     : m_keyData(src->m_keyData)
+    , m_centerData(src->m_centerData)
     , m_isPegbarsCycleEnabled(src->m_isPegbarsCycleEnabled)
     , m_offset(src->m_offset) {}
 
@@ -73,7 +74,10 @@ void TKeyframeData::setKeyframes(std::set<Position> positions, TXsheet *xsh,
     if (pegbar->isKeyframe(row)) {
       Position p(row - r0, col - c0);
       TStageObject::Keyframe k = pegbar->getKeyframe(row);
-      m_keyData[p]             = k;
+      TPointD center, offset;
+      pegbar->getCenterAndOffset(center, offset);
+      m_keyData[p]    = k;
+      m_centerData[p] = CenterInfo(center, offset);
     }
   }
 }
@@ -126,6 +130,10 @@ bool TKeyframeData::getKeyframes(std::set<Position> &positions,
     double e0, e1;
     pegbar->getKeyframeRange(kF, kL);
     pegbar->setKeyframeWithoutUndo(row, it->second);
+    CenterData::const_iterator centerIt = m_centerData.find(pos);
+    if (centerIt != m_centerData.end())
+      pegbar->setCenterAndOffset(centerIt->second.first,
+                                 centerIt->second.second);
 
     std::map<int, int>::iterator itF = firstRowCol.find(col);
     std::map<int, int>::iterator itL = lastRowCol.find(col);

--- a/toonz/sources/toonz/keyframedata.cpp
+++ b/toonz/sources/toonz/keyframedata.cpp
@@ -99,7 +99,7 @@ bool TKeyframeData::getKeyframes(std::set<Position> &positions,
     if (itL == lastRowCol.end())
       lastRowCol.insert(std::pair<int, int>(it2->second, it2->first));
     else
-      itL->second = c0;
+      itL->second = it2->first;
   }
 
   XsheetViewer *viewer = TApp::instance()->getCurrentXsheetViewer();

--- a/toonz/sources/toonz/keyframedata.h
+++ b/toonz/sources/toonz/keyframedata.h
@@ -20,8 +20,12 @@ public:
   typedef TKeyframeSelection::Position Position;
   typedef std::map<Position, TStageObject::Keyframe> KeyData;
   typedef std::map<Position, TStageObject::Keyframe>::const_iterator Iterator;
+  typedef std::pair<TPointD, TPointD> CenterInfo;
+  typedef std::map<Position, CenterInfo> CenterData;
+  typedef std::map<Position, CenterInfo>::const_iterator CenterIterator;
 
   KeyData m_keyData;
+  CenterData m_centerData;
   int m_columnSpanCount;
   int m_rowSpanCount;
 


### PR DESCRIPTION
## Problem

This draft begins work on the behavior reported in `opentoonz/opentoonz#6923` (**Mesh Key Deletion and Undo Bug**).

Holding **Alt** while moving selected keyframes uses the overwrite path in `KeyframeMover`. During interactive movement, the mover restores its starting snapshot by removing existing stage-object keyframes without undo and reconstructing them from `TKeyframeData`. If that snapshot does not contain all relevant stage-object state, an overwrite preview can be destructive before the final drag operation is committed.

The issue is especially concerning for mesh columns because the reported failure can remove all keys and leave no useful Undo path.

## Existing Tahoma2D work

Tahoma2D already addressed a closely related state-loss problem in commit `baecf75047194b3dade71c2331b7aaec73abdca3` (**Fix resetting center and offset on key delete**).

That change extended `TKeyframeData` so keyframe snapshots also preserve the stage object's **center and offset**, then restore those values when reconstructing keyframes. OpenToonz currently snapshots the keyframe data itself but not center/offset.

This PR adapts that portion of the Tahoma2D fix to the current OpenToonz code rather than treating the problem as a new implementation.

## Initial changes

- Preserve `TStageObject` center/offset alongside each stored keyframe in `TKeyframeData`.
- Restore center/offset when keyframes are reconstructed.
- Preserve the new center/offset data when `TKeyframeData` is cloned/copied.
- Correct an inherited `lastRowCol` bookkeeping defect where a **column index** (`c0`) was being stored as the **last row** value. The intended value is the current keyframe row (`it2->first`).

The `lastRowCol` defect is also present in current Tahoma2D code, so it is being kept as a separate small commit rather than attributed to the T2D center/offset change.

## Why this is still a Draft

This is the first containment step, not yet a claim that #6923 is fully resolved.

The deeper concern is that interactive keyframe dragging mutates the live scene with `*WithoutUndo()` operations before the drag is committed. The final Undo record is added only after release and is currently based primarily on row displacement. We should verify that a cancelled drag, a drag returned to its starting row, and overwrite of occupied destinations all restore the exact original state.

If the current patch does not fully eliminate #6923, the next step should be to make keyframe drag behavior more transactional: restore the complete starting snapshot for each preview, then create one undoable committed state only on release.

## Validation plan

Test on current OT-Dev with ordinary columns and mesh columns:

1. Create multiple stage-object/mesh keyframes with a non-default center/offset.
2. Alt-drag selected keys to an occupied destination.
3. Verify no unrelated keys disappear.
4. Verify center/offset remain unchanged by preview/reconstruction.
5. Undo and Redo the committed move.
6. Alt-drag, then return the selection to its original row before release; verify the scene state is unchanged.
7. Save/reopen after the operation and confirm the reconstructed scene matches the pre-save state.

Related upstream issue: https://github.com/opentoonz/opentoonz/issues/6923

Tahoma2D reference: https://github.com/tahoma2d/tahoma2d/commit/baecf75047194b3dade71c2331b7aaec73abdca3