### PR TITLE
Improve macOS crash report symbolication

### DIFF
--- a/toonz/sources/toonz/crashhandler.cpp
+++ b/toonz/sources/toonz/crashhandler.cpp
@@ -13,7 +13,11 @@
 #include <signal.h>
 #include <unistd.h>
 #include <err.h>
+#ifdef MACOSX
+#include <dlfcn.h>
+#else
 #include <regex>
+#endif
 #endif
 
 #include "tgl.h"
@@ -286,15 +290,22 @@ static bool sh(std::string &out, const char *cmd) {
 
 //-----------------------------------------------------------------------------
 
-static bool addr2line(std::string &out, const char *exepath, const char *addr) {
-  char cmd[512];
 #ifdef MACOSX
-  sprintf(cmd, "atos -o \"%.400s\" %s 2>&1", exepath, addr);
-#else
-  sprintf(cmd, "addr2line -f -p -e \"%.400s\" %s 2>&1", exepath, addr);
-#endif
+static bool addr2line(std::string &out, const char *modulePath,
+                      uintptr_t addr, uintptr_t loadAddr) {
+  char cmd[512];
+  snprintf(cmd, sizeof(cmd),
+           "atos -o \"%.400s\" -l 0x%" PRIxPTR " 0x%" PRIxPTR " 2>&1",
+           modulePath, loadAddr, addr);
   return sh(out, cmd);
 }
+#else
+static bool addr2line(std::string &out, const char *exepath, const char *addr) {
+  char cmd[512];
+  sprintf(cmd, "addr2line -f -p -e \"%.400s\" %s 2>&1", exepath, addr);
+  return sh(out, cmd);
+}
+#endif
 
 //-----------------------------------------------------------------------------
 
@@ -314,6 +325,48 @@ static void printBacktrace(std::string &out) {
   const int size = 256;
   void *buffer[size];
 
+#ifdef MACOSX
+  // Resolve each frame to the Mach-O image that actually contains it. This is
+  // required for dylib frames and for ASLR-aware symbolication with atos.
+  int nptrs = backtrace(buffer, size);
+  for (int i = 0; i < nptrs; ++i) {
+    // Skip first frames since they point to this function
+    if (frameStack++ < frameSkip) continue;
+    char numStr[32];
+    memset(numStr, 0, sizeof(numStr));
+    sprintf(numStr, "%3i> ", frameStack - frameSkip);
+    out.append(numStr);
+
+    std::string line;
+    bool found = false;
+
+    Dl_info info;
+    memset(&info, 0, sizeof(info));
+    if (dladdr(buffer[i], &info) && info.dli_fname && info.dli_fbase) {
+      uintptr_t addr     = reinterpret_cast<uintptr_t>(buffer[i]);
+      uintptr_t loadAddr = reinterpret_cast<uintptr_t>(info.dli_fbase);
+
+      if (addr2line(line, info.dli_fname, addr, loadAddr)) {
+        found = !line.empty() && line.rfind("atos: ", 0) != 0;
+      }
+
+      if (!found) {
+        char addrStr[64];
+        snprintf(addrStr, sizeof(addrStr), "0x%" PRIxPTR, addr);
+        out.append(addrStr);
+        out.append(" <");
+        out.append(filenameOnly(info.dli_fname));
+        out.append(">\n");
+      }
+    } else {
+      char addrStr[64];
+      snprintf(addrStr, sizeof(addrStr), "%p\n", buffer[i]);
+      out.append(addrStr);
+    }
+
+    if (found) out.append(line);
+  }
+#else
   // Get executable path
   char exepath[512];
   memset(exepath, 0, 512);
@@ -350,6 +403,7 @@ static void printBacktrace(std::string &out) {
   }
 
   free(bts);
+#endif
 }
 
 void signalHandler(int sig) {


### PR DESCRIPTION
## Problem

OpenToonz currently uses the same Unix backtrace path for Linux and macOS. On macOS that path attempts to resolve the executable with `/proc/self/exe`, which is Linux-specific, then tries to symbolize all frames against that single executable path. This makes macOS crash reports much less useful, especially when the important frame belongs to an OpenToonz dylib rather than the main executable.

This draft addresses the macOS crash-reporting weakness identified during the current bughunt. It is intended to improve diagnosis of macOS crash clusters where the top actionable frame is unresolved or reported only as `???`.

## Tahoma2D reference

Tahoma2D already uses a stronger approach in its crash handler: resolve each backtrace address to its containing image with `dladdr()` and pass the image load address to `atos` so symbolication accounts for ASLR and dylib frames.

This PR adapts only the minimum macOS-specific part of that approach rather than porting Tahoma2D's entire crash-handler implementation.

## Changes

- On macOS, use `dladdr()` to determine the Mach-O image containing each backtrace address.
- Call `atos` with both the image path and its load address (`-l`) so ASLR-relative symbol lookup is correct.
- Remove the macOS dependency on Linux-only `/proc/self/exe`.
- Keep a useful address/module fallback when `atos` cannot resolve a frame.

## Regression containment

This patch is deliberately narrow:

- **Windows crash handling is not intentionally changed.**
- **Linux retains its existing `/proc/self/exe`, `backtrace_symbols`, regex parsing, and `addr2line` path.**
- The new `dladdr()` implementation is compiled only under `MACOSX`.
- No Windows minidump, signal handling, dialog behavior, crash-file format, or project-reporting changes from Tahoma2D are being imported here.

The PR remains Draft until the final diff is checked for unintended cross-platform changes and macOS CI compiles the new path.

## Validation

1. Confirm Windows and Linux CI continue to build with their existing code paths.
2. Confirm macOS CI compiles and links `dladdr()` successfully.
3. Generate or capture a macOS crash report and verify frames from OpenToonz dylibs identify the correct module.
4. Verify `atos` receives the containing image's load address and produces a symbol when matching symbols are available.
5. Verify unresolved frames still retain a raw address and module name rather than disappearing.

This is a crash-**reporting** fix; it does not itself claim to fix the underlying crashes being diagnosed.