### PR TITLE
Fix: Correct 8-bit BMP header image size

### DIFF
--- a/toonz/sources/common/tiio/tiio_bmp.cpp
+++ b/toonz/sources/common/tiio/tiio_bmp.cpp
@@ -653,7 +653,7 @@ void BmpWriter::open(FILE *file, const TImageInfo &info) {
   assert(m_bitPerPixel == 8 || m_bitPerPixel == 24);
 
   int bytePerLine =
-      ((lx * m_bitPerPixel + 31) / 32) * (m_bitPerPixel == 8 ? 1 : 4);
+      ((lx * m_bitPerPixel + 31) / 32) * 4;
 
   int fileSize = 14                  // file header
                  + 40                // info header


### PR DESCRIPTION
## Problem

This draft addresses `opentoonz/opentoonz#6972` (**Rendering of Invalid 8bit Grayscale BMP files**).

OpenToonz writes the actual 8-bit grayscale BMP pixel payload correctly, but the BMP header reports an image size that is only one quarter of the real payload size.

The issue report measured a 1920×1080 8-bit BMP with:

- actual pixel data: **2,073,600 bytes**
- `biSizeImage`: **518,400 bytes**
- `bfSize`: correspondingly too small

The source calculation reproduces that exact 4× mismatch.

## Root cause

`BmpWriter::open()` computes the scanline size with:

```cpp
int bytePerLine =
    ((lx * m_bitPerPixel + 31) / 32) * (m_bitPerPixel == 8 ? 1 : 4);
```

The expression `(bitsPerLine + 31) / 32` yields a count of **32-bit DWORDs**. Converting that count to bytes therefore always requires multiplication by **4**.

For 1920 pixels at 8 bits per pixel:

- current calculation: `(1920 * 8 + 31) / 32 * 1 = 480 bytes/row`
- correct calculation: `(1920 * 8 + 31) / 32 * 4 = 1920 bytes/row`
- current `biSizeImage`: `480 * 1080 = 518,400`
- correct `biSizeImage`: `1920 * 1080 = 2,073,600`

This exactly matches the malformed header values observed in #6972.

## Change

Replace the conditional multiplier with the required DWORD-to-byte multiplier:

```cpp
int bytePerLine =
    ((lx * m_bitPerPixel + 31) / 32) * 4;
```

The existing 24-bit path already effectively used `* 4`, so its behavior is unchanged.

## Regression containment

This PR intentionally changes only the BMP header scanline-size calculation.

- The 8-bit pixel writer is unchanged; it already writes one grayscale byte per pixel and pads each row to a 4-byte boundary.
- The BMP reader is unchanged.
- Palette handling is unchanged.
- 24-bit BMP output is unchanged in effective calculation.
- The separate observation about long / non-8.3 filenames is **not** being treated as part of this fix and should remain a separate investigation.

The branch diff is one line: one deletion and one addition in `toonz/sources/common/tiio/tiio_bmp.cpp`.

## Validation

1. Render a 1920×1080 8-bit grayscale BMP.
2. Verify `biSizeImage == 2,073,600`.
3. Verify `bfSize` matches the actual file size (including headers and the 256-entry palette).
4. Reload/import the generated BMP in OpenToonz.
5. Test widths that require DWORD padding (for example 1919, 1921) to verify header size matches the bytes actually written per scanline.
6. Render/reload a 24-bit BMP to confirm no regression.

Related upstream issue: https://github.com/opentoonz/opentoonz/issues/6972

This is a focused fix for the reproducible invalid-header defect; it does not claim to resolve every BMP-related crash or filename-related failure.