### PR TITLE
[test] Tolerate unknown top-level scene data

### DIFF
--- a/toonz/sources/include/toonz/toonzscene.h
+++ b/toonz/sources/include/toonz/toonzscene.h
@@ -216,7 +216,7 @@ Code file path \b TFilePath.
   TFilePath codeFilePath(const TFilePath &) const;
   /*!
 Decode file path \b TFilePath.
-\sa codeFilePath()
+\sa decodeFilePath()
 */
   TFilePath decodeFilePath(const TFilePath &) const;
   /*!
@@ -310,6 +310,7 @@ private:
                      // TXshSimpleLevel::load().
 
   std::vector<std::string> m_unrecognizedSceneTags;
+  std::string m_loadedSceneGenerator;
 
 private:
   // noncopyable

--- a/toonz/sources/include/toonz/toonzscene.h
+++ b/toonz/sources/include/toonz/toonzscene.h
@@ -4,6 +4,8 @@
 #define TOONZSCENE_H
 
 #include <memory>
+#include <string>
+#include <vector>
 
 // TnzCore includes
 #include "tfilepath.h"
@@ -99,10 +101,19 @@ public:
 
   void clear();  //!< Clears the scene.
 
+  // The mutable-path overload allows save-time compatibility safeguards to
+  // redirect a save to a protected copy while keeping the caller's path in
+  // sync. The const overload preserves the existing API for callers that do
+  // not need path redirection.
   void save(
-      const TFilePath &path, TXsheet *subxsheet = 0,
+      TFilePath &path, TXsheet *subxsheet = 0,
       bool saveSceneIcon = true);  //!< Saves the scene (or a sub-xsheet) at the
                                     //!  specified path.
+  void save(const TFilePath &path, TXsheet *subxsheet = 0,
+            bool saveSceneIcon = true) {
+    TFilePath mutablePath(path);
+    save(mutablePath, subxsheet, saveSceneIcon);
+  }
   void loadTnzFile(
       const TFilePath &path);  //!< Loads scene data from file, \a excluding the
                                //!  associated project and the scene resources.
@@ -112,6 +123,17 @@ public:
       bool withProgressDialog = false);  //!< Loads the scene resources.
   void load(const TFilePath &path,
             bool withProgressDialog = false);  //!  Loads a scene from file.
+
+  // Unknown top-level scene tags are skipped during load rather than treated
+  // as malformed data. They are recorded so saving can warn that the skipped
+  // data cannot be round-tripped by this version of OpenToonz.
+  bool hasUnrecognizedSceneData() const {
+    return !m_unrecognizedSceneTags.empty();
+  }
+  const std::vector<std::string> &getUnrecognizedSceneTags() const {
+    return m_unrecognizedSceneTags;
+  }
+  void clearUnrecognizedSceneData() { m_unrecognizedSceneTags.clear(); }
 
   /*! \return   The \a coded path to be used for import. */
 
@@ -286,6 +308,8 @@ private:
                      // is used when loading PSD levels, for defining whether to
                      // convert a layerId in the path to the layer name. See
                      // TXshSimpleLevel::load().
+
+  std::vector<std::string> m_unrecognizedSceneTags;
 
 private:
   // noncopyable

--- a/toonz/sources/include/toonz/toonzscene.h
+++ b/toonz/sources/include/toonz/toonzscene.h
@@ -216,7 +216,7 @@ Code file path \b TFilePath.
   TFilePath codeFilePath(const TFilePath &) const;
   /*!
 Decode file path \b TFilePath.
-\sa decodeFilePath()
+\sa codeFilePath()
 */
   TFilePath decodeFilePath(const TFilePath &) const;
   /*!

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -48,6 +48,7 @@
 
 TOfflineGL *currentOfflineGL = 0;
 
+#include <QDateTime>
 #include <QMessageBox>
 #include <QProgressDialog>
 #include <QPushButton>
@@ -220,7 +221,8 @@ void fixBiancoProblem(ToonzScene *scene, TXsheet *xsh) {
     visited.insert(xsh);
     tovisit.erase(xsh);
     int c0 = 0, c1 = xsh->getColumnCount() - 1;
-    for (int c = c0; c <= c1; c++) {
+    for (int c = -1; c < c1 + 1; ++c) {
+      if (c < 0) continue;
       if (xsh->isColumnEmpty(c)) continue;
       TXshColumn *column = xsh->getColumn(c);
       if (!column || !column->getLevelColumn()) continue;
@@ -606,17 +608,22 @@ void ToonzScene::save(TFilePath &fp, TXsheet *subxsh, bool saveSceneIcon) {
 
   // Unknown top-level data was intentionally skipped at load time. On an
   // explicit save back to the same scene, protect that original file by
-  // defaulting to a free incremented filename. Autosave passes
-  // saveSceneIcon=false, and sub-xsheet saves have their own target, so neither
-  // enters this modal compatibility decision.
+  // defaulting to a timestamped copy. Autosave passes saveSceneIcon=false,
+  // and sub-xsheet saves have their own target, so neither enters this modal
+  // compatibility decision.
   if (saveSceneIcon && !subxsh && newScenePath == oldScenePath &&
       hasUnrecognizedSceneData()) {
-    NameModifier modifier(newScenePath.getWideName());
-    TFilePath suggestedPath;
-    do {
-      suggestedPath = newScenePath.withName(modifier.getNext());
-    } while (suggestedPath == newScenePath ||
-             TSystem::doesExistFileOrLevel(decodeFilePath(suggestedPath)));
+    const QString timestamp =
+        QDateTime::currentDateTime().toString("yyyyMMdd_HHmmss");
+    const std::wstring timestampedBaseName =
+        newScenePath.getWideName() + L"_" + timestamp.toStdWString();
+
+    TFilePath suggestedPath = newScenePath.withName(timestampedBaseName);
+    int collisionIndex      = 1;
+    while (TSystem::doesExistFileOrLevel(decodeFilePath(suggestedPath))) {
+      suggestedPath = newScenePath.withName(
+          timestampedBaseName + L"_" + std::to_wstring(collisionIndex++));
+    }
 
     QStringList tags;
     const int maxTags = 8;
@@ -638,7 +645,7 @@ void ToonzScene::save(TFilePath &fp, TXsheet *subxsh, bool saveSceneIcon) {
             "The scene was opened by safely ignoring those entries. Saving "
             "the scene will not write the unrecognized data back.\n\n"
             "To preserve the original scene unchanged, save the recognized "
-            "scene data to the suggested incremented file.")
+            "scene data to the suggested timestamped file.")
             .arg(tags.join(", ")));
     QPushButton *saveCopyButton = msgBox.addButton(
         QObject::tr("Save as %1")

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -286,7 +286,8 @@ ToonzScene::ToonzScene()
     : m_contentHistory(0)
     , m_isUntitled(true)
     , m_isLoading(false)
-    , m_unrecognizedSceneTags() {
+    , m_unrecognizedSceneTags()
+    , m_loadedSceneGenerator() {
   m_childStack = new ChildStack(this);
   m_properties = new TSceneProperties();
   m_levelSet   = new TLevelSet();
@@ -321,6 +322,7 @@ void ToonzScene::clear() {
   delete properties;
   m_levelSet->clear();
   m_unrecognizedSceneTags.clear();
+  m_loadedSceneGenerator.clear();
 }
 
 //-----------------------------------------------------------------------------
@@ -444,6 +446,7 @@ void ToonzScene::loadResources(bool withProgressDialog) {
 void ToonzScene::loadTnzFile(const TFilePath &fp) {
   bool reading22 = false;
   m_unrecognizedSceneTags.clear();
+  m_loadedSceneGenerator.clear();
   TIStream is(fp);
   if (!is) throw TException(fp.getWideString() + L": Can't open file");
   try {
@@ -465,10 +468,10 @@ void ToonzScene::loadTnzFile(const TFilePath &fp) {
       is.setVersion(versionNumber);
       while (is.matchTag(tagName)) {
         if (tagName == "generator") {
-          std::string program = is.getString();
+          m_loadedSceneGenerator = is.getString();
           // TODO: This obsolete condition should be removed before releasing OT
           // v2.2 !
-          reading22 = program.find("2.2") != std::string::npos;
+          reading22 = m_loadedSceneGenerator.find("2.2") != std::string::npos;
         } else if (tagName == "properties")
           m_properties->loadData(is, false);
         else if (tagName == "palette")  // per compatibilita' beta1
@@ -634,18 +637,27 @@ void ToonzScene::save(TFilePath &fp, TXsheet *subxsh, bool saveSceneIcon) {
       tags << QObject::tr("and %1 more")
                   .arg((int)m_unrecognizedSceneTags.size() - maxTags);
 
+    QString generatorInfo;
+    if (!m_loadedSceneGenerator.empty())
+      generatorInfo =
+          QObject::tr(
+              "\n\nThe scene was created or last saved with %1. For full "
+              "compatibility, open the original scene with that application/"
+              "version or a release known to support its features.")
+              .arg(QString::fromStdString(m_loadedSceneGenerator));
+
     QMessageBox msgBox;
     msgBox.setIcon(QMessageBox::Warning);
     msgBox.setWindowTitle(QObject::tr("Unrecognized Scene Data"));
     msgBox.setText(
         QObject::tr(
-            "This scene contains data that this version of OpenToonz does not "
-            "recognize:\n\n%1\n\n"
-            "The scene was opened by safely ignoring those entries. Saving "
-            "the scene will not write the unrecognized data back.\n\n"
+            "This scene contains data OpenToonz does not recognize.%1\n\n"
+            "Unrecognized entries: %2\n\n"
+            "OpenToonz can continue loading recognized data. Saving will not "
+            "write the unrecognized data back.\n\n"
             "To preserve the original scene unchanged, save the recognized "
             "scene data to the suggested timestamped file.")
-            .arg(tags.join(", ")));
+            .arg(generatorInfo, tags.join(", ")));
     QPushButton *saveCopyButton = msgBox.addButton(
         QObject::tr("Save as %1")
             .arg(suggestedPath.withoutParentDir().getQString()),
@@ -1293,7 +1305,6 @@ TXshLevel *ToonzScene::loadLevel(const TFilePath &actualPath,
     if (lp->getDpiPolicy() == LevelProperties::DP_ImageDpi) {
       // We must check whether the image actually has a dpi.
       const TPointD &imageDpi = xl->getImageDpi();
-
       if (imageDpi == TPointD() ||
           Preferences::instance()->getUnits() == "pixel" ||
           Preferences::instance()->isIgnoreImageDpiEnabled()) {

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -1305,6 +1305,7 @@ TXshLevel *ToonzScene::loadLevel(const TFilePath &actualPath,
     if (lp->getDpiPolicy() == LevelProperties::DP_ImageDpi) {
       // We must check whether the image actually has a dpi.
       const TPointD &imageDpi = xl->getImageDpi();
+
       if (imageDpi == TPointD() ||
           Preferences::instance()->getUnits() == "pixel" ||
           Preferences::instance()->isIgnoreImageDpiEnabled()) {

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -221,8 +221,7 @@ void fixBiancoProblem(ToonzScene *scene, TXsheet *xsh) {
     visited.insert(xsh);
     tovisit.erase(xsh);
     int c0 = 0, c1 = xsh->getColumnCount() - 1;
-    for (int c = -1; c < c1 + 1; ++c) {
-      if (c < 0) continue;
+    for (int c = c0; c <= c1; c++) {
       if (xsh->isColumnEmpty(c)) continue;
       TXshColumn *column = xsh->getColumn(c);
       if (!column || !column->getLevelColumn()) continue;

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -48,7 +48,12 @@
 
 TOfflineGL *currentOfflineGL = 0;
 
+#include <QMessageBox>
 #include <QProgressDialog>
+#include <QPushButton>
+#include <QStringList>
+
+#include <algorithm>
 
 #if defined(MACOSX) || defined(LINUX) || defined(FREEBSD)
 #include <QSurfaceFormat>
@@ -277,7 +282,10 @@ static void deleteAllUntitledScenes() {
 // ToonzScene
 
 ToonzScene::ToonzScene()
-    : m_contentHistory(0), m_isUntitled(true), m_isLoading(false) {
+    : m_contentHistory(0)
+    , m_isUntitled(true)
+    , m_isLoading(false)
+    , m_unrecognizedSceneTags() {
   m_childStack = new ChildStack(this);
   m_properties = new TSceneProperties();
   m_levelSet   = new TLevelSet();
@@ -311,6 +319,7 @@ void ToonzScene::clear() {
   m_properties                 = new TSceneProperties();
   delete properties;
   m_levelSet->clear();
+  m_unrecognizedSceneTags.clear();
 }
 
 //-----------------------------------------------------------------------------
@@ -400,7 +409,7 @@ void ToonzScene::loadNoResources(const TFilePath &fp) {
  * プログレスダイアログをGUIからの実行時でのみ表示させる。tcomposerから実行の場合は表示させない
  * --*/
 void ToonzScene::loadResources(bool withProgressDialog) {
-  /*--- m_levelSet->getLevelCount()が10個以上のとき表示させる　---*/
+  /*--- m_levelSet->getLevelCount()が10個以上で表示させる　---*/
   QProgressDialog *progressDialog = 0;
   if (withProgressDialog && m_levelSet->getLevelCount() >= 10) {
     progressDialog = new QProgressDialog("Loading Scene Resources", "", 0,
@@ -433,6 +442,7 @@ void ToonzScene::loadResources(bool withProgressDialog) {
 
 void ToonzScene::loadTnzFile(const TFilePath &fp) {
   bool reading22 = false;
+  m_unrecognizedSceneTags.clear();
   TIStream is(fp);
   if (!is) throw TException(fp.getWideString() + L": Can't open file");
   try {
@@ -495,8 +505,18 @@ void ToonzScene::loadTnzFile(const TFilePath &fp) {
           }
           TContentHistory *history = getContentHistory(true);
           history->deserialize(QString::fromStdString(historyData));
-        } else
-          throw TException(tagName + " : unexpected tag");
+        } else {
+          // Treat unknown top-level scene entries as optional extension data.
+          // The parser already knows how to skip a complete nested tag. Record
+          // the tag so a later explicit save can protect the source file from
+          // silently losing data that this version cannot round-trip.
+          if (std::find(m_unrecognizedSceneTags.begin(),
+                        m_unrecognizedSceneTags.end(),
+                        tagName) == m_unrecognizedSceneTags.end())
+            m_unrecognizedSceneTags.push_back(tagName);
+          is.skipCurrentTag();
+          continue;
+        }
 
         if (!is.matchEndTag()) throw TException(tagName + " : missing end tag");
       }
@@ -580,19 +600,76 @@ public:
 
 //-----------------------------------------------------------------------------
 
-void ToonzScene::save(const TFilePath &fp, TXsheet *subxsh,
-                      bool saveSceneIcon) {
+void ToonzScene::save(TFilePath &fp, TXsheet *subxsh, bool saveSceneIcon) {
   TFilePath oldScenePath = getScenePath();
   TFilePath newScenePath = fp;
 
+  // Unknown top-level data was intentionally skipped at load time. On an
+  // explicit save back to the same scene, protect that original file by
+  // defaulting to a free incremented filename. Autosave passes
+  // saveSceneIcon=false, and sub-xsheet saves have their own target, so neither
+  // enters this modal compatibility decision.
+  if (saveSceneIcon && !subxsh && newScenePath == oldScenePath &&
+      hasUnrecognizedSceneData()) {
+    NameModifier modifier(newScenePath.getWideName());
+    TFilePath suggestedPath;
+    do {
+      suggestedPath = newScenePath.withName(modifier.getNext());
+    } while (suggestedPath == newScenePath ||
+             TSystem::doesExistFileOrLevel(decodeFilePath(suggestedPath)));
+
+    QStringList tags;
+    const int maxTags = 8;
+    for (int i = 0;
+         i < (int)m_unrecognizedSceneTags.size() && i < maxTags; ++i)
+      tags << QString("<%1>").arg(
+          QString::fromStdString(m_unrecognizedSceneTags[i]));
+    if ((int)m_unrecognizedSceneTags.size() > maxTags)
+      tags << QObject::tr("and %1 more")
+                  .arg((int)m_unrecognizedSceneTags.size() - maxTags);
+
+    QMessageBox msgBox;
+    msgBox.setIcon(QMessageBox::Warning);
+    msgBox.setWindowTitle(QObject::tr("Unrecognized Scene Data"));
+    msgBox.setText(
+        QObject::tr(
+            "This scene contains data that this version of OpenToonz does not "
+            "recognize:\n\n%1\n\n"
+            "The scene was opened by safely ignoring those entries. Saving "
+            "the scene will not write the unrecognized data back.\n\n"
+            "To preserve the original scene unchanged, save the recognized "
+            "scene data to the suggested incremented file.")
+            .arg(tags.join(", ")));
+    QPushButton *saveCopyButton = msgBox.addButton(
+        QObject::tr("Save as %1")
+            .arg(suggestedPath.withoutParentDir().getQString()),
+        QMessageBox::AcceptRole);
+    QPushButton *overwriteButton =
+        msgBox.addButton(QObject::tr("Overwrite Original"),
+                         QMessageBox::DestructiveRole);
+    Q_UNUSED(overwriteButton);
+    msgBox.setDefaultButton(saveCopyButton);
+    // This low-level save method has no cancellation result to return to its
+    // callers. For this first compatibility experiment, require one of the two
+    // explicit safe-save decisions rather than allowing the window-close path
+    // to be misreported as a successful save.
+    msgBox.setWindowFlag(Qt::WindowCloseButtonHint, false);
+    msgBox.exec();
+
+    if (msgBox.clickedButton() == saveCopyButton) {
+      newScenePath = suggestedPath;
+      fp           = suggestedPath;
+    }
+  }
+
   if (newScenePath != oldScenePath)
-    TProjectManager::instance()->loadSceneProject(fp, &m_standAlone);
+    TProjectManager::instance()->loadSceneProject(newScenePath, &m_standAlone);
 
   CameraRedirection redir(this, subxsh);
 
   bool wasUntitled = isUntitled();
 
-  setScenePath(fp);
+  setScenePath(newScenePath);
 
   TFileStatus fs(newScenePath);
   if (fs.doesExist() && !fs.isWritable())
@@ -600,7 +677,7 @@ void ToonzScene::save(const TFilePath &fp, TXsheet *subxsh,
                            "The scene cannot be saved: it is a read only "
                            "scene.\n All resources have been saved.");
 
-  TFilePath scenePath = decodeFilePath(fp);
+  TFilePath scenePath = decodeFilePath(newScenePath);
   TFilePath scenePathTemp(scenePath.getWideString() +
                           QString(".tmp").toStdWString());
 
@@ -691,6 +768,7 @@ void ToonzScene::save(const TFilePath &fp, TXsheet *subxsh,
     if (wasUntitled) setUntitled();
   } else {
     if (wasUntitled) deleteUntitledScene(oldScenePath.getParentDir());
+    if (saveSceneIcon) clearUnrecognizedSceneData();
   }
   // update the last saved version
   setVersionNumber(l_currentVersion);
@@ -744,8 +822,6 @@ void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
 
     painter.flushRasterImages();
     glFlush();
-
-    TRop::over(ras, ogl.getRaster());
   }
   ogl.doneCurrent();
 
@@ -757,7 +833,7 @@ void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
 //! Performs a camera-stand render of the specified xsheet in the specified
 //! placedRect,
 //! with known world/placed reference change - and returns the result in a
-//! 32-bit raster.
+// 32-bit raster.
 
 void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
                              const TRectD &placedRect,
@@ -862,7 +938,6 @@ TXshLevel *ToonzScene::createNewLevel(int type, std::wstring levelName,
                                       const TDimension &dim, double dpi,
                                       TFilePath fp) {
   TLevelSet *levelSet = getLevelSet();
-
   if (type == TZI_XSHLEVEL)  // TZI type corresponds to the 'Scan Level'
     type = OVL_XSHLEVEL;     // default option. See Toonz Preferences class.
 
@@ -1209,7 +1284,6 @@ TXshLevel *ToonzScene::loadLevel(const TFilePath &actualPath,
     if (lp->getDpiPolicy() == LevelProperties::DP_ImageDpi) {
       // We must check whether the image actually has a dpi.
       const TPointD &imageDpi = xl->getImageDpi();
-
       if (imageDpi == TPointD() ||
           Preferences::instance()->getUnits() == "pixel" ||
           Preferences::instance()->isIgnoreImageDpiEnabled()) {

--- a/toonz/sources/toonzlib/toonzscene.cpp
+++ b/toonz/sources/toonzlib/toonzscene.cpp
@@ -409,7 +409,7 @@ void ToonzScene::loadNoResources(const TFilePath &fp) {
  * プログレスダイアログをGUIからの実行時でのみ表示させる。tcomposerから実行の場合は表示させない
  * --*/
 void ToonzScene::loadResources(bool withProgressDialog) {
-  /*--- m_levelSet->getLevelCount()が10個以上で表示させる　---*/
+  /*--- m_levelSet->getLevelCount()が10個以上のとき表示させる　---*/
   QProgressDialog *progressDialog = 0;
   if (withProgressDialog && m_levelSet->getLevelCount() >= 10) {
     progressDialog = new QProgressDialog("Loading Scene Resources", "", 0,
@@ -822,6 +822,8 @@ void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
 
     painter.flushRasterImages();
     glFlush();
+
+    TRop::over(ras, ogl.getRaster());
   }
   ogl.doneCurrent();
 
@@ -833,7 +835,7 @@ void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
 //! Performs a camera-stand render of the specified xsheet in the specified
 //! placedRect,
 //! with known world/placed reference change - and returns the result in a
-// 32-bit raster.
+//! 32-bit raster.
 
 void ToonzScene::renderFrame(const TRaster32P &ras, int row, const TXsheet *xsh,
                              const TRectD &placedRect,
@@ -938,6 +940,7 @@ TXshLevel *ToonzScene::createNewLevel(int type, std::wstring levelName,
                                       const TDimension &dim, double dpi,
                                       TFilePath fp) {
   TLevelSet *levelSet = getLevelSet();
+
   if (type == TZI_XSHLEVEL)  // TZI type corresponds to the 'Scan Level'
     type = OVL_XSHLEVEL;     // default option. See Toonz Preferences class.
 
@@ -1284,6 +1287,7 @@ TXshLevel *ToonzScene::loadLevel(const TFilePath &actualPath,
     if (lp->getDpiPolicy() == LevelProperties::DP_ImageDpi) {
       // We must check whether the image actually has a dpi.
       const TPointD &imageDpi = xl->getImageDpi();
+
       if (imageDpi == TPointD() ||
           Preferences::instance()->getUnits() == "pixel" ||
           Preferences::instance()->isIgnoreImageDpiEnabled()) {


### PR DESCRIPTION
## Status: scope locked for compatibility testing

This PR remains intentionally limited to **future-proofing the top-level `.tnz` scene container**. The parser behavior is ready for focused testing. One UI refinement is now specified for this draft: when incompatible scene data is detected, retain and report the scene's `<generator>` provenance so the warning can direct the user toward the application/release most likely to preserve full fidelity.

## Goal

Allow newer or fork-specific **top-level scene entries** to exist in a `.tnz` file without causing older/current OpenToonz builds to reject the entire scene as malformed, while preserving strict validation for known structures and malformed data.

## What this PR currently accomplishes

- Unknown **top-level** tags encountered by `ToonzScene::loadTnzFile()` are treated as optional/comment-like scene data rather than as a fatal `unexpected tag` error.
- The existing `TIStream::skipCurrentTag()` mechanism skips the complete nested unknown structure so scene loading can continue.
- The scene records the names of top-level tags that were skipped.
- Known scene structures continue to use their existing strict parsing and malformed-data checks.
- Unknown content nested inside known structures is **not** made permissive by this PR.
- A scene that loads with skipped top-level data is flagged as containing data that this OpenToonz version cannot round-trip.
- On an explicit Save back to the same scene, OpenToonz warns the user before incompatible data can be lost.
- The default preservation action saves recognized scene data to a new file named from the source scene plus the save-time timestamp, e.g. `Shot014_20260815_100856.tnz`.
- If that exact timestamped name already exists, `_1`, `_2`, etc. are used only as a collision fallback.
- The original scene remains untouched when the protected-copy option is used.
- The user may explicitly choose to overwrite the original instead.
- Autosave and sub-Xsheet saves do not enter this modal compatibility decision.

## Compatibility warning refinement

Scene files already contain a `<generator>` entry. This draft should retain that value when the scene contains unrecognized data and use it as provenance in the compatibility notification.

The agreed concise warning is:

> **This scene contains data OpenToonz does not recognize.**  
> The scene was created or last saved with **Tahoma2D 1.x**. For full compatibility, open the original scene with that application/version or a release known to support its features.  
> OpenToonz can continue loading recognized data.

`Tahoma2D 1.x` is an example. The implementation should display the actual generator string reported by the scene rather than hardcoding a particular fork or version.

The wording deliberately says **created or last saved with** because `<generator>` identifies the application that wrote the current scene file; it does not necessarily identify where the scene originally began.

For the save dialog, the concise compatibility warning can remain the primary text while save-specific information is secondary: which tags were skipped, that the current build cannot write them back, and that the timestamped copy preserves the original scene file unchanged.

## Why this is intentionally top-level only

This PR does **not** establish the rule that all unknown data is harmless. Unknown fields nested inside a known object may materially change that object's meaning, so those loaders remain strict. The top-level scene container is the safest boundary at which to test forward-compatible extension handling.

Compatibility rule:

- known + valid data -> parse normally
- known + malformed data -> fail as before
- unknown top-level structured data -> skip, flag, and continue

## Potential shortfalls / follow-up work

1. **Skipped payload is not yet preserved.** The current implementation records skipped tag names, not the exact source text. A follow-up should extend `TIStream::skipCurrentTag()` so it can optionally return the skipped text and ideally its source line/location.
2. **Generator provenance is specified but not yet retained by the branch.** The loader currently reads `<generator>` for legacy compatibility logic and then discards it. The next small code refinement is to retain that string only for compatibility reporting.
3. **No View/Export Skipped Data action yet.** Once skipped source can be retained, OpenToonz should be able to show it as comment-like compatibility information and optionally export a text compatibility record.
4. **Top-level only.** Unknown nested fields inside known scene objects remain strict by design. Any broader tolerance should be audited loader-by-loader rather than enabled globally.
5. **Unknown does not necessarily mean optional.** A future feature could theoretically place required scene semantics in a top-level tag. This PR favors opening the scene while making the loss risk explicit; visual/semantic validation of such scenes still matters.
6. **The timestamped copy does not preserve unknown data.** It contains only data understood by the current build; the untouched original remains the fidelity-preserving source.
7. **Project discovery compatibility is separate from `.tnz` parsing.** Tahoma2D's `tahomaproject.xml` discovery incompatibility is now being handled independently in OpenToonz-Dev PR #82.

## Relationship to Tahoma2D project compatibility

PR #82 addresses the earlier project-discovery barrier: recognizing `tahomaproject.xml` without renaming it. This PR addresses the next layer: once OpenToonz reaches the `.tnz`, tolerate structurally valid unknown **top-level** scene entries instead of rejecting the whole scene.

That gives us a layered compatibility path:

```text
project discovery (#82)
        ↓
scene container ingest (#81)
        ↓
recognized scene data loads normally
unknown top-level data is skipped + reported
```

## Suggested test matrix

### Baseline
- Open and save several existing OpenToonz scenes with no unknown data.
- Confirm behavior and serialized scene content remain unchanged apart from normal save-time differences.

### Forward-compatibility test
- Copy a valid `.tnz` and insert a synthetic top-level entry such as:

```xml
<futureSceneMetadata>
  <author>Test</author>
  <note>Forward compatibility probe</note>
</futureSceneMetadata>
```

- Confirm the scene opens successfully.
- Confirm known scene content loads normally.
- Confirm the scene records that `futureSceneMetadata` was skipped.

### Tahoma2D scene test
- Use a basic untouched Tahoma2D scene with PR #82 so the project is discovered without renaming `tahomaproject.xml`.
- Confirm a simple scene opens when its scene content is otherwise OpenToonz-compatible.
- Then test a Tahoma2D scene containing fork-specific top-level `.tnz` entries.
- Confirm #81 allows recognized scene content to load rather than treating the entire scene as malformed.
- Once generator retention is implemented, confirm the warning reports the actual Tahoma2D generator/version string.

### Save protection
- Save a loaded scene containing skipped data.
- Confirm the warning appears.
- Accept the default protected save.
- Confirm a timestamped file is created from the source scene name.
- Confirm the original `.tnz` remains byte-for-byte untouched.
- Confirm the timestamped copy contains recognized scene data but not the unknown extension tag.

### Explicit overwrite
- Reload the original compatibility-test scene.
- Choose Overwrite Original.
- Confirm the file saves successfully and the unknown data is removed as warned.

### Strictness regression tests
- Corrupt a known tag or known nested structure.
- Confirm malformed known scene data still fails exactly as before.
- Insert unknown data inside a known structure and confirm this PR has not silently broadened nested parser tolerance.

## Success criteria

This PR succeeds if OpenToonz can open a scene containing structurally valid but unknown **top-level** data, preserve all recognized scene behavior, identify the application/release that last wrote the scene when available, clearly explain the compatibility risk, and prevent accidental destruction of the original scene while retaining existing malformed-data strictness.

This remains a draft/test PR in **OpenAnimationLibrary/opentoonz-dev** so the compatibility policy can be validated before any upstream proposal.