### PR TITLE
Fix: Recognize Tahoma2D project files

### DIFF
--- a/toonz/sources/toonzlib/tproject.cpp
+++ b/toonz/sources/toonzlib/tproject.cpp
@@ -38,6 +38,7 @@ using namespace std;
 const std::wstring prjSuffix[4] = {L"_otprj", L"_prj63ml", L"_prj6", L"_prj"};
 const std::wstring xmlExt       = L".xml";
 const int prjSuffixCount        = 4;
+const std::wstring tahomaProjectFileName = L"tahomaproject.xml";
 
 //===================================================================
 /*! Default inputs folder: is used to save all scanned immage.*/
@@ -137,6 +138,13 @@ TFilePath getProjectFile(const TFilePath &fp) {
     if (prjfiles.size()) return fp + TFilePath(prjfiles[0]);
   }
 
+  // Tahoma2D stores otherwise-compatible project metadata in a fixed
+  // tahomaproject.xml file. Keep OpenToonz project files as the preferred
+  // discovery result when both formats are present, but accept a Tahoma2D
+  // project in place when it is the available project descriptor.
+  TFilePath tahomaProjectPath = fp + tahomaProjectFileName;
+  if (TFileStatus(tahomaProjectPath).doesExist()) return tahomaProjectPath;
+
   return TFilePath();
 }
 
@@ -214,7 +222,6 @@ void hideOlderProjectFiles(const TFilePath &folderPath) {
 //
 // TProject
 //
-
 //-------------------------------------------------------------------
 
 /*! \class TProject tproject.h
@@ -710,6 +717,7 @@ void TProject::load(const TFilePath &projectPath) {
 bool TProject::isAProjectPath(const TFilePath &fp) {
   if (fp.isAbsolute() && fp.getType() == "xml") {
     const std::wstring &fpName = fp.getWideName();
+    if (fpName == L"tahomaproject") return true;
     for (int i = 0; i < prjSuffixCount; ++i)
       if (fpName.find(prjSuffix[i]) != std::wstring::npos) return true;
   }


### PR DESCRIPTION
## Problem

OpenToonz scenes stored in a Tahoma2D project can fail to open even when the `.tnz` scene itself is otherwise compatible.

The immediate cause is project discovery. Tahoma2D uses a fixed project metadata filename:

```text
tahomaproject.xml
```

Tahoma2D explicitly recognizes that filename and also falls back to OpenToonz-style project files. OpenToonz currently recognizes only its historical project naming patterns:

```text
*_otprj.xml
*_prj63ml.xml
*_prj6.xml
*_prj.xml
```

As a result, users can often make the same Tahoma2D scene open in OpenToonz simply by renaming the project XML to an OpenToonz-recognized name. This PR removes that unnecessary filename incompatibility.

## Scope

This PR is intentionally limited to **project compatibility discovery**.

It does not attempt to make OpenToonz generally compatible with every Tahoma2D project or scene feature. It only allows OpenToonz to recognize an existing `tahomaproject.xml` as a project descriptor and proceed through the normal project/scene loading path.

## Changes

Two checks are required:

1. **Project discovery**
   - After checking the existing OpenToonz project filename patterns, `getProjectFile()` now also checks for `tahomaproject.xml`.
   - Existing OpenToonz project files remain preferred when both an OpenToonz descriptor and `tahomaproject.xml` are present. This avoids changing current OpenToonz project-selection behavior.

2. **Project-path validation**
   - `TProject::isAProjectPath()` now accepts the exact filename `tahomaproject.xml` in addition to the existing OpenToonz suffix-based names.
   - This is necessary because `loadSceneProject()` validates the discovered absolute project path before loading it.

## What does not change

- OpenToonz does **not** begin naming newly created projects `tahomaproject.xml`.
- The normal OpenToonz project naming convention remains unchanged.
- Existing OpenToonz project discovery remains first priority.
- Tahoma project files are not renamed or converted merely because OpenToonz opens them.
- `.tnz` scene parsing behavior is not changed by this PR.
- No Tahoma-specific scene features are enabled or emulated.

## Save behavior

`getLatestVersionProjectPath()` only upgrades recognized legacy OpenToonz suffixes. `tahomaproject.xml` has no such suffix, so its path is left unchanged.

Therefore, when OpenToonz loads a Tahoma project through this compatibility path, the project descriptor can remain `tahomaproject.xml` rather than being automatically renamed to an OpenToonz filename.

## Why OpenToonz files remain preferred

Tahoma2D itself prefers `tahomaproject.xml` and then falls back to OpenToonz-style project descriptors. For OpenToonz, the safer compatibility policy is the reverse:

```text
OpenToonz project descriptor present -> preserve existing OpenToonz behavior
otherwise tahomaproject.xml present   -> accept it as compatible project metadata
```

This adds interoperability without changing which project file an existing OpenToonz project would select.

## Suggested validation

### Existing OpenToonz project

1. Open a normal OpenToonz project using `*_otprj.xml`.
2. Confirm project discovery and scene loading are unchanged.
3. Save project settings and confirm OpenToonz continues using its existing project filename.

### Tahoma2D project

1. Use a project containing `tahomaproject.xml` and no OpenToonz-named project XML.
2. Confirm OpenToonz discovers the project without renaming any files.
3. Open a `.tnz` scene from the project.
4. Confirm project folder aliases resolve from the Tahoma project metadata.
5. Save/reopen and confirm the project remains discoverable.

### Both project descriptors present

1. Place an OpenToonz project descriptor and `tahomaproject.xml` in the same project folder.
2. Confirm OpenToonz continues selecting its existing OpenToonz descriptor first.

### Invalid/non-project XML

1. Confirm arbitrary XML files are not accepted merely because they are in a project folder.
2. Confirm only the exact `tahomaproject.xml` name receives the compatibility allowance.

## Potential shortfalls / follow-up work

- This PR assumes the Tahoma project XML content being opened is compatible with OpenToonz's existing `TProject::load()` parser. Filename discovery is the known blocker addressed here; Tahoma-specific project fields may still require separate compatibility work if encountered.
- Project metadata that references Tahoma-only resources or conventions may still load incompletely.
- Scene-level format differences remain separate. The companion OpenToonz-Dev scene-parser experiment (#81) addresses forward-tolerant top-level `.tnz` parsing and is intentionally independent from this project-discovery fix.
- A future interoperability test fixture containing a minimal real Tahoma2D project would be useful for regression coverage.

## Success criteria

This PR succeeds if a Tahoma2D project that currently opens in OpenToonz only after renaming `tahomaproject.xml` can instead be discovered and opened **without modifying the project filename**, while existing OpenToonz project behavior remains unchanged.

This is staged as a draft in **OpenAnimationLibrary/opentoonz-dev** for focused compatibility testing before considering an upstream PR.