### PR TITLE
Allow auto-orientation of Command Bar

### DIFF
--- a/toonz/sources/toonz/commandbar.cpp
+++ b/toonz/sources/toonz/commandbar.cpp
@@ -27,8 +27,9 @@
 #include <QActionGroup>
 
 namespace {
-constexpr int kCommandBarFloatingThickness = 36;
-constexpr int kCommandBarDockedThickness   = 26;
+constexpr int kCommandBarFloatingThickness  = 36;
+constexpr int kCommandBarDockedThickness    = 26;
+constexpr int kCommandBarFloatingFrameDelta = 10;
 }
 
 //=============================================================================
@@ -174,9 +175,6 @@ void CommandBar::contextMenuEvent(QContextMenuEvent *event) {
     verticalAction->setChecked(orientation() == Qt::Vertical);
     orientationGroup->addAction(verticalAction);
 
-    // A docked Command Bar follows the orientation of its docking slot. Manual
-    // orientation remains available while floating; dragging to another side
-    // automatically selects the appropriate orientation before docking.
     TPanel *panel = qobject_cast<TPanel *>(parentWidget());
     orientationMenu->setEnabled(!panel || panel->isFloating());
 
@@ -223,9 +221,7 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
 
   const bool vertical = orientation == Qt::Vertical;
 
-  // The existing Command Bar QSS is horizontally biased. Keep the normal
-  // themed styling for horizontal mode, and use symmetric spacing in vertical
-  // mode so the icons remain centered in a narrow column.
+  // Vertical mode overrides horizontal-biased theme spacing.
   if (vertical) {
     setStyleSheet(
         "QToolBar#CommandBar { margin: 0; padding: 0; border: 0; }"
@@ -246,9 +242,6 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
     setStyleSheet(QString());
   }
 
-  // CommandBarPanel is intentionally a very thin wrapper around this toolbar.
-  // Keep its dock/title-bar orientation and fixed thickness synchronized here
-  // so old room layouts need no special-case migration code.
   TPanel *panel = qobject_cast<TPanel *>(parentWidget());
   if (!panel) return;
 
@@ -258,18 +251,14 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
   const bool floating = panel->isFloating();
   const int thickness = floating ? kCommandBarFloatingThickness
                                  : kCommandBarDockedThickness;
-  // TDockWidget removes its 5px floating frame on docking. Keep enough
-  // long-axis minimum while floating so that subtraction resolves cleanly to 0.
-  const int minimumLongSide = floating ? 10 : 0;
+  const int minimumLongSide = floating ? kCommandBarFloatingFrameDelta : 0;
 
   if (vertical) {
     panel->setMinimumHeight(minimumLongSide);
     panel->setMaximumHeight(QWIDGETSIZE_MAX);
     panel->setFixedWidth(thickness);
 
-    // The shipped Command Bar theme constrains its title bar to a narrow left
-    // strip. In vertical mode the title bar moves to the top, so release that
-    // width constraint while retaining the normal 18px title-bar thickness.
+    // Release the horizontal title-bar constraint in vertical mode.
     if (TPanelTitleBar *titleBar = panel->getTitleBar()) {
       titleBar->setStyleSheet(
           "TPanelTitleBar {"

--- a/toonz/sources/toonz/commandbar.cpp
+++ b/toonz/sources/toonz/commandbar.cpp
@@ -31,11 +31,12 @@
 #include <QShowEvent>
 
 namespace {
-constexpr int kCommandBarFloatingThickness   = 36;
-constexpr int kCommandBarDockedThickness     = 26;
-constexpr int kCommandBarFloatingFrameDelta  = 10;
-constexpr int kCommandBarTitleBarThickness   = 18;
-constexpr int kCommandBarHorizontalGripWidth = 20;
+constexpr int kCommandBarFloatingThickness       = 36;
+constexpr int kCommandBarDockedThickness         = 26;
+constexpr int kCommandBarFloatingFrameDelta      = 10;
+constexpr int kCommandBarTitleBarThickness       = 18;
+constexpr int kCommandBarHorizontalGripWidth     = 20;
+constexpr int kCommandBarVerticalExtensionHeight = 16;
 }
 
 //=============================================================================
@@ -276,20 +277,24 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
   // Vertical mode overrides horizontal-biased theme spacing.
   if (vertical) {
     setStyleSheet(
-        "QToolBar#CommandBar { margin: 0; padding: 0; border: 0; }"
-        "QToolBar#CommandBar::separator:vertical {"
-        "  margin: 2px 2px 0 2px;"
-        "}"
-        "QToolBar#CommandBar QToolButton {"
-        "  margin: 2px 0 0 0;"
-        "  padding: 0;"
-        "  min-width: 20px;"
-        "  min-height: 20px;"
-        "}"
-        "QToolBar#CommandBar QToolButton#qt_toolbar_ext_button {"
-        "  margin: 0;"
-        "  padding: 0;"
-        "}");
+        QStringLiteral(
+            "QToolBar#CommandBar { margin: 0; padding: 0; border: 0; }"
+            "QToolBar#CommandBar::separator:vertical {"
+            "  margin: 2px 2px 0 2px;"
+            "}"
+            "QToolBar#CommandBar QToolButton {"
+            "  margin: 2px 0 0 0;"
+            "  padding: 0;"
+            "  min-width: 20px;"
+            "  min-height: 20px;"
+            "}"
+            "QToolBar#CommandBar QToolButton#qt_toolbar_ext_button {"
+            "  margin: 0;"
+            "  padding: 0;"
+            "  min-height: %1px;"
+            "  max-height: %1px;"
+            "}")
+            .arg(kCommandBarVerticalExtensionHeight));
   } else {
     setStyleSheet(QString());
   }

--- a/toonz/sources/toonz/commandbar.cpp
+++ b/toonz/sources/toonz/commandbar.cpp
@@ -25,11 +25,13 @@
 #include <QMenuBar>
 #include <QContextMenuEvent>
 #include <QActionGroup>
+#include <QLayout>
 
 namespace {
 constexpr int kCommandBarFloatingThickness  = 36;
 constexpr int kCommandBarDockedThickness    = 26;
 constexpr int kCommandBarFloatingFrameDelta = 10;
+constexpr int kCommandBarTitleBarThickness  = 18;
 }
 
 //=============================================================================
@@ -253,29 +255,39 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
                                  : kCommandBarDockedThickness;
   const int minimumLongSide = floating ? kCommandBarFloatingFrameDelta : 0;
 
+  TPanelTitleBar *titleBar = panel->getTitleBar();
   if (vertical) {
     panel->setMinimumHeight(minimumLongSide);
     panel->setMaximumHeight(QWIDGETSIZE_MAX);
     panel->setFixedWidth(thickness);
 
-    // Release the horizontal title-bar constraint in vertical mode.
-    if (TPanelTitleBar *titleBar = panel->getTitleBar()) {
+    if (titleBar) {
       titleBar->setStyleSheet(
           "TPanelTitleBar {"
-          "  max-width: 16777215;"
-          "  max-height: 18;"
           "  border-right: 0;"
           "  border-bottom: 0;"
           "  border-radius: 0;"
           "}");
+      titleBar->setMaximumWidth(QWIDGETSIZE_MAX);
+      titleBar->setMaximumHeight(kCommandBarTitleBarThickness);
     }
   } else {
     panel->setMinimumWidth(minimumLongSide);
     panel->setMaximumWidth(QWIDGETSIZE_MAX);
     panel->setFixedHeight(thickness);
 
-    if (TPanelTitleBar *titleBar = panel->getTitleBar())
+    if (titleBar) {
       titleBar->setStyleSheet(QString());
+      titleBar->setMaximumWidth(kCommandBarTitleBarThickness);
+      titleBar->setMaximumHeight(QWIDGETSIZE_MAX);
+    }
+  }
+
+  if (titleBar) titleBar->updateGeometry();
+  panel->updateGeometry();
+  if (panel->layout()) {
+    panel->layout()->invalidate();
+    panel->layout()->activate();
   }
 }
 

--- a/toonz/sources/toonz/commandbar.cpp
+++ b/toonz/sources/toonz/commandbar.cpp
@@ -313,15 +313,19 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
 
     if (titleBar) {
       titleBar->setStyleSheet(
-          "TPanelTitleBar {"
-          "  min-width: 0;"
-          "  max-width: 16777215;"
-          "  min-height: 18;"
-          "  max-height: 18;"
-          "  border-right: 0;"
-          "  border-bottom: 0;"
-          "  border-radius: 0;"
-          "}");
+          QStringLiteral(
+              "TPanelTitleBar {"
+              "  min-width: 0;"
+              "  max-width: %1;"
+              "  min-height: %2;"
+              "  max-height: %2;"
+              "  border-right: 0;"
+              "  border-bottom: 0;"
+              "  border-radius: 0;"
+              "}")
+              .arg(QWIDGETSIZE_MAX)
+              .arg(kCommandBarTitleBarThickness));
+      titleBar->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
       titleBar->setMinimumWidth(0);
       titleBar->setMaximumWidth(QWIDGETSIZE_MAX);
       titleBar->setFixedHeight(kCommandBarTitleBarThickness);
@@ -333,12 +337,16 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
 
     if (titleBar) {
       titleBar->setStyleSheet(
-          "TPanelTitleBar {"
-          "  min-width: 20;"
-          "  max-width: 20;"
-          "  min-height: 0;"
-          "  max-height: 16777215;"
-          "}");
+          QStringLiteral(
+              "TPanelTitleBar {"
+              "  min-width: %1;"
+              "  max-width: %1;"
+              "  min-height: 0;"
+              "  max-height: %2;"
+              "}")
+              .arg(kCommandBarHorizontalGripWidth)
+              .arg(QWIDGETSIZE_MAX));
+      titleBar->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
       titleBar->setFixedWidth(kCommandBarHorizontalGripWidth);
       titleBar->setMinimumHeight(0);
       titleBar->setMaximumHeight(QWIDGETSIZE_MAX);

--- a/toonz/sources/toonz/commandbar.cpp
+++ b/toonz/sources/toonz/commandbar.cpp
@@ -26,13 +26,16 @@
 #include <QContextMenuEvent>
 #include <QActionGroup>
 #include <QLayout>
+#include <QGuiApplication>
+#include <QScreen>
+#include <QShowEvent>
 
 namespace {
-constexpr int kCommandBarFloatingThickness  = 36;
-constexpr int kCommandBarDockedThickness    = 26;
-constexpr int kCommandBarFloatingFrameDelta = 10;
-constexpr int kCommandBarTitleBarThickness  = 18;
-constexpr int kCommandBarHorizontalGripWidth = 40;
+constexpr int kCommandBarFloatingThickness   = 36;
+constexpr int kCommandBarDockedThickness     = 26;
+constexpr int kCommandBarFloatingFrameDelta  = 10;
+constexpr int kCommandBarTitleBarThickness   = 18;
+constexpr int kCommandBarHorizontalGripWidth = 20;
 }
 
 //=============================================================================
@@ -43,7 +46,9 @@ CommandBar::CommandBar(QWidget *parent, Qt::WindowFlags flags,
                        bool isCollapsible, bool isXsheetToolbar)
     : QToolBar(parent)
     , m_isCollapsible(isCollapsible)
-    , m_isXsheetToolbar(isXsheetToolbar) {
+    , m_isXsheetToolbar(isXsheetToolbar)
+    , m_roomStateLoaded(false)
+    , m_initialFloatingSizeApplied(false) {
   setObjectName("cornerWidget");
   setObjectName("CommandBar");
   fillToolbar(this, isXsheetToolbar);
@@ -206,15 +211,56 @@ void CommandBar::save(QSettings &settings) const {
 void CommandBar::load(QSettings &settings) {
   if (m_isXsheetToolbar) return;
 
+  m_roomStateLoaded = settings.contains(QStringLiteral("roomBound"));
+
   const QString savedOrientation =
       settings.value(QStringLiteral("orientation"),
                      QStringLiteral("Horizontal"))
           .toString();
+  const Qt::Orientation saved =
+      savedOrientation.compare(QStringLiteral("Vertical"), Qt::CaseInsensitive) ==
+              0
+          ? Qt::Vertical
+          : Qt::Horizontal;
 
-  setOrientation(savedOrientation.compare(QStringLiteral("Vertical"),
-                                          Qt::CaseInsensitive) == 0
-                     ? Qt::Vertical
-                     : Qt::Horizontal);
+  if (orientation() == saved)
+    onOrientationChanged(saved);
+  else
+    setOrientation(saved);
+
+  if (!m_roomStateLoaded) applyInitialFloatingSize();
+}
+
+//-----------------------------------------------------------------------------
+
+void CommandBar::showEvent(QShowEvent *event) {
+  QToolBar::showEvent(event);
+  if (m_roomStateLoaded || m_initialFloatingSizeApplied) return;
+  onOrientationChanged(orientation());
+  applyInitialFloatingSize();
+}
+
+//-----------------------------------------------------------------------------
+
+void CommandBar::applyInitialFloatingSize() {
+  if (m_initialFloatingSizeApplied || m_roomStateLoaded) return;
+
+  TPanel *panel = qobject_cast<TPanel *>(parentWidget());
+  if (!panel || !panel->isFloating()) return;
+
+  QScreen *screen = QGuiApplication::screenAt(panel->frameGeometry().center());
+  if (!screen) screen = QGuiApplication::primaryScreen();
+  if (!screen) return;
+
+  QSize panelSize       = panel->size();
+  const QRect available = screen->availableGeometry();
+  if (orientation() == Qt::Vertical)
+    panelSize.setHeight(available.height() / 2);
+  else
+    panelSize.setWidth(available.width() / 2);
+
+  panel->resize(panelSize);
+  m_initialFloatingSizeApplied = true;
 }
 
 //-----------------------------------------------------------------------------
@@ -288,8 +334,8 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
     if (titleBar) {
       titleBar->setStyleSheet(
           "TPanelTitleBar {"
-          "  min-width: 40;"
-          "  max-width: 40;"
+          "  min-width: 20;"
+          "  max-width: 20;"
           "  min-height: 0;"
           "  max-height: 16777215;"
           "}");

--- a/toonz/sources/toonz/commandbar.cpp
+++ b/toonz/sources/toonz/commandbar.cpp
@@ -31,6 +31,7 @@
 #include <QShowEvent>
 #include <QResizeEvent>
 #include <QStyleOptionToolBar>
+#include <QTimer>
 #include <QToolButton>
 
 namespace {
@@ -58,6 +59,7 @@ CommandBar::CommandBar(QWidget *parent, Qt::WindowFlags flags,
     , m_autoCompact(false)
     , m_compactPresentation(false)
     , m_compactTransition(false)
+    , m_compactUpdatePending(false)
     , m_compactThreshold(0)
     , m_compactMenu(nullptr)
     , m_compactButton(nullptr)
@@ -256,14 +258,14 @@ void CommandBar::load(QSettings &settings) {
     setOrientation(saved);
 
   if (!m_roomStateLoaded) applyInitialFloatingSize();
-  updateCompactState();
+  scheduleCompactUpdate();
 }
 
 //-----------------------------------------------------------------------------
 
 void CommandBar::resizeEvent(QResizeEvent *event) {
   QToolBar::resizeEvent(event);
-  updateCompactState();
+  scheduleCompactUpdate();
 }
 
 //-----------------------------------------------------------------------------
@@ -274,7 +276,7 @@ void CommandBar::showEvent(QShowEvent *event) {
     onOrientationChanged(orientation());
     applyInitialFloatingSize();
   }
-  updateCompactState();
+  scheduleCompactUpdate();
 }
 
 //-----------------------------------------------------------------------------
@@ -347,6 +349,18 @@ int CommandBar::compactThreshold() const {
 
 //-----------------------------------------------------------------------------
 
+void CommandBar::scheduleCompactUpdate() {
+  if (m_isXsheetToolbar || m_compactUpdatePending) return;
+
+  m_compactUpdatePending = true;
+  QTimer::singleShot(0, this, [this]() {
+    m_compactUpdatePending = false;
+    updateCompactState();
+  });
+}
+
+//-----------------------------------------------------------------------------
+
 void CommandBar::updateCompactState() {
   if (m_isXsheetToolbar || m_compactTransition) return;
 
@@ -387,7 +401,7 @@ void CommandBar::rebuildCompactMenu() {
   if (m_userCompact) {
     QAction *expandAction = m_compactMenu->addAction(tr("Expand"));
     connect(expandAction, &QAction::triggered, this,
-            [this]() { setUserCompact(false); });
+            [this]() { setUserCompact(false); }, Qt::QueuedConnection);
   }
 
   QAction *customizeAction =
@@ -561,7 +575,7 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
     panel->layout()->invalidate();
     panel->layout()->activate();
   }
-  updateCompactState();
+  scheduleCompactUpdate();
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/commandbar.cpp
+++ b/toonz/sources/toonz/commandbar.cpp
@@ -325,7 +325,7 @@ void CommandBar::applyCompactPanelSize(bool compact) {
 
   if (compact) {
     if (m_expandedLongSide <= 0 && currentLongSide > compactLongSide)
-      m_expandedLongSide = currentLongSide;
+      m_expandedLongSide = qMax(currentLongSide, m_compactThreshold);
 
     if (vertical)
       panel->setFixedHeight(compactLongSide);
@@ -425,8 +425,15 @@ void CommandBar::updateCompactState() {
     if (threshold > 0) m_compactThreshold = threshold;
   }
 
-  const int extent =
-      orientation() == Qt::Horizontal ? width() : height();
+  int extent = orientation() == Qt::Horizontal ? width() : height();
+  if (m_compactPresentation && !m_userCompact) {
+    const int normalGripDelta =
+        orientation() == Qt::Horizontal
+            ? kCommandBarHorizontalGripWidth - kCommandBarCompactGripSize
+            : kCommandBarTitleBarThickness - kCommandBarCompactGripSize;
+    extent = qMax(0, extent - normalGripDelta);
+  }
+
   m_autoCompact = !m_userCompact && m_compactThreshold > 0 &&
                   extent < m_compactThreshold;
 
@@ -499,6 +506,8 @@ void CommandBar::setCompactPresentation(bool compact) {
     m_compactButton->setAutoRaise(true);
     m_compactButton->setFixedSize(kCommandBarCompactButtonSize,
                                   kCommandBarCompactButtonSize);
+    m_compactButton->setStyleSheet(
+        "QToolButton#CommandBarCompactButton { margin: 0; padding: 0; }");
     m_compactButton->setToolTip(tr("Command Bar"));
     m_compactButton->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(m_compactButton, &QWidget::customContextMenuRequested, this,

--- a/toonz/sources/toonz/commandbar.cpp
+++ b/toonz/sources/toonz/commandbar.cpp
@@ -27,7 +27,8 @@
 #include <QActionGroup>
 
 namespace {
-constexpr int kCommandBarThickness = 36;
+constexpr int kCommandBarFloatingThickness = 36;
+constexpr int kCommandBarDockedThickness   = 26;
 }
 
 //=============================================================================
@@ -173,6 +174,12 @@ void CommandBar::contextMenuEvent(QContextMenuEvent *event) {
     verticalAction->setChecked(orientation() == Qt::Vertical);
     orientationGroup->addAction(verticalAction);
 
+    // A docked Command Bar follows the orientation of its docking slot. Manual
+    // orientation remains available while floating; dragging to another side
+    // automatically selects the appropriate orientation before docking.
+    TPanel *panel = qobject_cast<TPanel *>(parentWidget());
+    orientationMenu->setEnabled(!panel || panel->isFloating());
+
     connect(horizontalAction, &QAction::triggered, this,
             [this]() { setOrientation(Qt::Horizontal); });
     connect(verticalAction, &QAction::triggered, this,
@@ -248,10 +255,17 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
   panel->setOrientation(vertical ? TDockWidget::vertical
                                  : TDockWidget::horizontal);
 
+  const bool floating = panel->isFloating();
+  const int thickness = floating ? kCommandBarFloatingThickness
+                                 : kCommandBarDockedThickness;
+  // TDockWidget removes its 5px floating frame on docking. Keep enough
+  // long-axis minimum while floating so that subtraction resolves cleanly to 0.
+  const int minimumLongSide = floating ? 10 : 0;
+
   if (vertical) {
-    panel->setMinimumHeight(0);
+    panel->setMinimumHeight(minimumLongSide);
     panel->setMaximumHeight(QWIDGETSIZE_MAX);
-    panel->setFixedWidth(kCommandBarThickness);
+    panel->setFixedWidth(thickness);
 
     // The shipped Command Bar theme constrains its title bar to a narrow left
     // strip. In vertical mode the title bar moves to the top, so release that
@@ -267,9 +281,9 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
           "}");
     }
   } else {
-    panel->setMinimumWidth(0);
+    panel->setMinimumWidth(minimumLongSide);
     panel->setMaximumWidth(QWIDGETSIZE_MAX);
-    panel->setFixedHeight(kCommandBarThickness);
+    panel->setFixedHeight(thickness);
 
     if (TPanelTitleBar *titleBar = panel->getTitleBar())
       titleBar->setStyleSheet(QString());

--- a/toonz/sources/toonz/commandbar.cpp
+++ b/toonz/sources/toonz/commandbar.cpp
@@ -32,6 +32,7 @@ constexpr int kCommandBarFloatingThickness  = 36;
 constexpr int kCommandBarDockedThickness    = 26;
 constexpr int kCommandBarFloatingFrameDelta = 10;
 constexpr int kCommandBarTitleBarThickness  = 18;
+constexpr int kCommandBarHorizontalGripWidth = 40;
 }
 
 //=============================================================================
@@ -223,6 +224,9 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
 
   const bool vertical = orientation == Qt::Vertical;
 
+  // QToolBar resets its size policy when orientation changes.
+  setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
   // Vertical mode overrides horizontal-biased theme spacing.
   if (vertical) {
     setStyleSheet(
@@ -264,12 +268,17 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
     if (titleBar) {
       titleBar->setStyleSheet(
           "TPanelTitleBar {"
+          "  min-width: 0;"
+          "  max-width: 16777215;"
+          "  min-height: 18;"
+          "  max-height: 18;"
           "  border-right: 0;"
           "  border-bottom: 0;"
           "  border-radius: 0;"
           "}");
+      titleBar->setMinimumWidth(0);
       titleBar->setMaximumWidth(QWIDGETSIZE_MAX);
-      titleBar->setMaximumHeight(kCommandBarTitleBarThickness);
+      titleBar->setFixedHeight(kCommandBarTitleBarThickness);
     }
   } else {
     panel->setMinimumWidth(minimumLongSide);
@@ -277,14 +286,26 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
     panel->setFixedHeight(thickness);
 
     if (titleBar) {
-      titleBar->setStyleSheet(QString());
-      titleBar->setMaximumWidth(kCommandBarTitleBarThickness);
+      titleBar->setStyleSheet(
+          "TPanelTitleBar {"
+          "  min-width: 40;"
+          "  max-width: 40;"
+          "  min-height: 0;"
+          "  max-height: 16777215;"
+          "}");
+      titleBar->setFixedWidth(kCommandBarHorizontalGripWidth);
+      titleBar->setMinimumHeight(0);
       titleBar->setMaximumHeight(QWIDGETSIZE_MAX);
     }
   }
 
   if (titleBar) titleBar->updateGeometry();
+  updateGeometry();
   panel->updateGeometry();
+  if (layout()) {
+    layout()->invalidate();
+    layout()->activate();
+  }
   if (panel->layout()) {
     panel->layout()->invalidate();
     panel->layout()->activate();

--- a/toonz/sources/toonz/commandbar.cpp
+++ b/toonz/sources/toonz/commandbar.cpp
@@ -42,6 +42,7 @@ constexpr int kCommandBarTitleBarThickness       = 18;
 constexpr int kCommandBarHorizontalGripWidth     = 20;
 constexpr int kCommandBarVerticalExtensionHeight = 16;
 constexpr int kCommandBarCompactButtonSize       = 20;
+constexpr int kCommandBarCompactGripSize         = 4;
 }
 
 //=============================================================================
@@ -61,6 +62,7 @@ CommandBar::CommandBar(QWidget *parent, Qt::WindowFlags flags,
     , m_compactTransition(false)
     , m_compactUpdatePending(false)
     , m_compactThreshold(0)
+    , m_expandedLongSide(0)
     , m_compactMenu(nullptr)
     , m_compactButton(nullptr)
     , m_compactWidgetAction(nullptr) {
@@ -232,6 +234,11 @@ void CommandBar::save(QSettings &settings) const {
                         ? QStringLiteral("Vertical")
                         : QStringLiteral("Horizontal"));
   settings.setValue(QStringLiteral("compact"), m_userCompact);
+  if (m_expandedLongSide > 0)
+    settings.setValue(QStringLiteral("compactExpandedLength"),
+                      m_expandedLongSide);
+  else
+    settings.remove(QStringLiteral("compactExpandedLength"));
 }
 
 //-----------------------------------------------------------------------------
@@ -241,6 +248,8 @@ void CommandBar::load(QSettings &settings) {
 
   m_roomStateLoaded = settings.contains(QStringLiteral("roomBound"));
   m_userCompact = settings.value(QStringLiteral("compact"), false).toBool();
+  m_expandedLongSide =
+      settings.value(QStringLiteral("compactExpandedLength"), 0).toInt();
 
   const QString savedOrientation =
       settings.value(QStringLiteral("orientation"),
@@ -300,6 +309,53 @@ void CommandBar::applyInitialFloatingSize() {
 
   panel->resize(panelSize);
   m_initialFloatingSizeApplied = true;
+}
+
+//-----------------------------------------------------------------------------
+
+void CommandBar::applyCompactPanelSize(bool compact) {
+  TPanel *panel = qobject_cast<TPanel *>(parentWidget());
+  if (!panel) return;
+
+  const bool vertical = orientation() == Qt::Vertical;
+  const int frameDelta = panel->isFloating() ? kCommandBarFloatingFrameDelta : 0;
+  const int compactLongSide = kCommandBarCompactButtonSize +
+                              kCommandBarCompactGripSize + frameDelta;
+  const int currentLongSide = vertical ? panel->height() : panel->width();
+
+  if (compact) {
+    if (m_expandedLongSide <= 0 && currentLongSide > compactLongSide)
+      m_expandedLongSide = currentLongSide;
+
+    if (vertical)
+      panel->setFixedHeight(compactLongSide);
+    else
+      panel->setFixedWidth(compactLongSide);
+    return;
+  }
+
+  const int minimumLongSide = panel->isFloating() ? kCommandBarFloatingFrameDelta : 0;
+  if (vertical) {
+    panel->setMinimumHeight(minimumLongSide);
+    panel->setMaximumHeight(QWIDGETSIZE_MAX);
+  } else {
+    panel->setMinimumWidth(minimumLongSide);
+    panel->setMaximumWidth(QWIDGETSIZE_MAX);
+  }
+
+  int restoreLongSide = m_expandedLongSide;
+  if (restoreLongSide <= compactLongSide)
+    restoreLongSide = qMax(m_compactThreshold, compactLongSide + 1);
+
+  if (restoreLongSide > 0) {
+    QSize panelSize = panel->size();
+    if (vertical)
+      panelSize.setHeight(restoreLongSide);
+    else
+      panelSize.setWidth(restoreLongSide);
+    panel->resize(panelSize);
+  }
+  m_expandedLongSide = 0;
 }
 
 //-----------------------------------------------------------------------------
@@ -375,6 +431,7 @@ void CommandBar::updateCompactState() {
                   extent < m_compactThreshold;
 
   setCompactPresentation(m_userCompact || m_autoCompact);
+  if (m_userCompact && m_compactPresentation) applyCompactPanelSize(true);
 }
 
 //-----------------------------------------------------------------------------
@@ -382,8 +439,15 @@ void CommandBar::updateCompactState() {
 void CommandBar::setUserCompact(bool compact) {
   if (m_userCompact == compact) return;
   m_userCompact = compact;
-  if (m_compactPresentation) rebuildCompactMenu();
-  updateCompactState();
+
+  if (compact) {
+    updateCompactState();
+    applyCompactPanelSize(true);
+    if (m_compactPresentation) rebuildCompactMenu();
+  } else {
+    applyCompactPanelSize(false);
+    updateCompactState();
+  }
 }
 
 //-----------------------------------------------------------------------------
@@ -462,6 +526,8 @@ void CommandBar::setCompactPresentation(bool compact) {
     for (QAction *action : restoreActions) addAction(action);
   }
 
+  onOrientationChanged(orientation());
+
   if (layout()) {
     layout()->invalidate();
     layout()->activate();
@@ -515,6 +581,12 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
   const int thickness = floating ? kCommandBarFloatingThickness
                                  : kCommandBarDockedThickness;
   const int minimumLongSide = floating ? kCommandBarFloatingFrameDelta : 0;
+  const int titleBarThickness =
+      m_compactPresentation ? kCommandBarCompactGripSize
+                            : kCommandBarTitleBarThickness;
+  const int horizontalGripWidth =
+      m_compactPresentation ? kCommandBarCompactGripSize
+                            : kCommandBarHorizontalGripWidth;
 
   TPanelTitleBar *titleBar = panel->getTitleBar();
   if (vertical) {
@@ -535,11 +607,11 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
               "  border-radius: 0;"
               "}")
               .arg(QWIDGETSIZE_MAX)
-              .arg(kCommandBarTitleBarThickness));
+              .arg(titleBarThickness));
       titleBar->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
       titleBar->setMinimumWidth(0);
       titleBar->setMaximumWidth(QWIDGETSIZE_MAX);
-      titleBar->setFixedHeight(kCommandBarTitleBarThickness);
+      titleBar->setFixedHeight(titleBarThickness);
     }
   } else {
     panel->setMinimumWidth(minimumLongSide);
@@ -555,10 +627,10 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
               "  min-height: 0;"
               "  max-height: %2;"
               "}")
-              .arg(kCommandBarHorizontalGripWidth)
+              .arg(horizontalGripWidth)
               .arg(QWIDGETSIZE_MAX));
       titleBar->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
-      titleBar->setFixedWidth(kCommandBarHorizontalGripWidth);
+      titleBar->setFixedWidth(horizontalGripWidth);
       titleBar->setMinimumHeight(0);
       titleBar->setMaximumHeight(QWIDGETSIZE_MAX);
     }
@@ -575,6 +647,7 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
     panel->layout()->invalidate();
     panel->layout()->activate();
   }
+  if (m_userCompact && m_compactPresentation) applyCompactPanelSize(true);
   scheduleCompactUpdate();
 }
 

--- a/toonz/sources/toonz/commandbar.cpp
+++ b/toonz/sources/toonz/commandbar.cpp
@@ -29,6 +29,9 @@
 #include <QGuiApplication>
 #include <QScreen>
 #include <QShowEvent>
+#include <QResizeEvent>
+#include <QStyleOptionToolBar>
+#include <QToolButton>
 
 namespace {
 constexpr int kCommandBarFloatingThickness       = 36;
@@ -37,6 +40,7 @@ constexpr int kCommandBarFloatingFrameDelta      = 10;
 constexpr int kCommandBarTitleBarThickness       = 18;
 constexpr int kCommandBarHorizontalGripWidth     = 20;
 constexpr int kCommandBarVerticalExtensionHeight = 16;
+constexpr int kCommandBarCompactButtonSize       = 20;
 }
 
 //=============================================================================
@@ -49,7 +53,15 @@ CommandBar::CommandBar(QWidget *parent, Qt::WindowFlags flags,
     , m_isCollapsible(isCollapsible)
     , m_isXsheetToolbar(isXsheetToolbar)
     , m_roomStateLoaded(false)
-    , m_initialFloatingSizeApplied(false) {
+    , m_initialFloatingSizeApplied(false)
+    , m_userCompact(false)
+    , m_autoCompact(false)
+    , m_compactPresentation(false)
+    , m_compactTransition(false)
+    , m_compactThreshold(0)
+    , m_compactMenu(nullptr)
+    , m_compactButton(nullptr)
+    , m_compactWidgetAction(nullptr) {
   setObjectName("cornerWidget");
   setObjectName("CommandBar");
   fillToolbar(this, isXsheetToolbar);
@@ -162,6 +174,12 @@ void CommandBar::buildDefaultToolbar(CommandBar *toolbar) {
 //-----------------------------------------------------------------------------
 
 void CommandBar::contextMenuEvent(QContextMenuEvent *event) {
+  showContextMenu(event->globalPos());
+}
+
+//-----------------------------------------------------------------------------
+
+void CommandBar::showContextMenu(const QPoint &globalPos) {
   QMenu menu(this);
   QAction *customizeCommandBar = menu.addAction(tr("Customize Command Bar"));
   connect(customizeCommandBar, SIGNAL(triggered()),
@@ -191,9 +209,15 @@ void CommandBar::contextMenuEvent(QContextMenuEvent *event) {
             [this]() { setOrientation(Qt::Horizontal); });
     connect(verticalAction, &QAction::triggered, this,
             [this]() { setOrientation(Qt::Vertical); });
+
+    QAction *compactAction = menu.addAction(tr("Compact"));
+    compactAction->setCheckable(true);
+    compactAction->setChecked(m_userCompact);
+    connect(compactAction, &QAction::toggled, this,
+            [this](bool checked) { setUserCompact(checked); });
   }
 
-  menu.exec(event->globalPos());
+  menu.exec(globalPos);
 }
 
 //-----------------------------------------------------------------------------
@@ -205,6 +229,7 @@ void CommandBar::save(QSettings &settings) const {
                     orientation() == Qt::Vertical
                         ? QStringLiteral("Vertical")
                         : QStringLiteral("Horizontal"));
+  settings.setValue(QStringLiteral("compact"), m_userCompact);
 }
 
 //-----------------------------------------------------------------------------
@@ -213,6 +238,7 @@ void CommandBar::load(QSettings &settings) {
   if (m_isXsheetToolbar) return;
 
   m_roomStateLoaded = settings.contains(QStringLiteral("roomBound"));
+  m_userCompact = settings.value(QStringLiteral("compact"), false).toBool();
 
   const QString savedOrientation =
       settings.value(QStringLiteral("orientation"),
@@ -230,15 +256,25 @@ void CommandBar::load(QSettings &settings) {
     setOrientation(saved);
 
   if (!m_roomStateLoaded) applyInitialFloatingSize();
+  updateCompactState();
+}
+
+//-----------------------------------------------------------------------------
+
+void CommandBar::resizeEvent(QResizeEvent *event) {
+  QToolBar::resizeEvent(event);
+  updateCompactState();
 }
 
 //-----------------------------------------------------------------------------
 
 void CommandBar::showEvent(QShowEvent *event) {
   QToolBar::showEvent(event);
-  if (m_roomStateLoaded || m_initialFloatingSizeApplied) return;
-  onOrientationChanged(orientation());
-  applyInitialFloatingSize();
+  if (!m_roomStateLoaded && !m_initialFloatingSizeApplied) {
+    onOrientationChanged(orientation());
+    applyInitialFloatingSize();
+  }
+  updateCompactState();
 }
 
 //-----------------------------------------------------------------------------
@@ -262,6 +298,162 @@ void CommandBar::applyInitialFloatingSize() {
 
   panel->resize(panelSize);
   m_initialFloatingSizeApplied = true;
+}
+
+//-----------------------------------------------------------------------------
+
+int CommandBar::compactThreshold() const {
+  if (m_compactPresentation) return m_compactThreshold;
+
+  QStyleOptionToolBar option;
+  initStyleOption(&option);
+
+  const int margin =
+      style()->pixelMetric(QStyle::PM_ToolBarItemMargin, &option, this) +
+      style()->pixelMetric(QStyle::PM_ToolBarFrameWidth, &option, this);
+  const int spacing =
+      style()->pixelMetric(QStyle::PM_ToolBarItemSpacing, &option, this);
+  const int extension =
+      style()->pixelMetric(QStyle::PM_ToolBarExtensionExtent, &option, this);
+
+  const QList<QAction *> toolbarActions = actions();
+  int totalItems                       = 0;
+  for (QAction *action : toolbarActions) {
+    if (action->isVisible() && widgetForAction(action)) ++totalItems;
+  }
+
+  int extent   = margin * 2;
+  int items    = 0;
+  int commands = 0;
+  for (QAction *action : toolbarActions) {
+    if (!action->isVisible()) continue;
+    QWidget *widget = widgetForAction(action);
+    if (!widget) continue;
+
+    if (items) extent += spacing;
+    const QSize hint = widget->sizeHint();
+    extent += orientation() == Qt::Horizontal ? hint.width() : hint.height();
+    ++items;
+
+    if (!action->isSeparator()) ++commands;
+    if (commands == 2) {
+      if (totalItems > items) extent += spacing + extension;
+      return extent;
+    }
+  }
+
+  return 0;
+}
+
+//-----------------------------------------------------------------------------
+
+void CommandBar::updateCompactState() {
+  if (m_isXsheetToolbar || m_compactTransition) return;
+
+  if (!m_compactPresentation) {
+    const int threshold = compactThreshold();
+    if (threshold > 0) m_compactThreshold = threshold;
+  }
+
+  const int extent =
+      orientation() == Qt::Horizontal ? width() : height();
+  m_autoCompact = !m_userCompact && m_compactThreshold > 0 &&
+                  extent < m_compactThreshold;
+
+  setCompactPresentation(m_userCompact || m_autoCompact);
+}
+
+//-----------------------------------------------------------------------------
+
+void CommandBar::setUserCompact(bool compact) {
+  if (m_userCompact == compact) return;
+  m_userCompact = compact;
+  if (m_compactPresentation) rebuildCompactMenu();
+  updateCompactState();
+}
+
+//-----------------------------------------------------------------------------
+
+void CommandBar::rebuildCompactMenu() {
+  if (!m_compactMenu) return;
+
+  m_compactMenu->clear();
+  for (QAction *action : m_compactActions) m_compactMenu->addAction(action);
+
+  if (!m_compactActions.isEmpty() &&
+      !m_compactActions.last()->isSeparator())
+    m_compactMenu->addSeparator();
+
+  if (m_userCompact) {
+    QAction *expandAction = m_compactMenu->addAction(tr("Expand"));
+    connect(expandAction, &QAction::triggered, this,
+            [this]() { setUserCompact(false); });
+  }
+
+  QAction *customizeAction =
+      m_compactMenu->addAction(tr("Customize Command Bar"));
+  connect(customizeAction, &QAction::triggered, this,
+          &CommandBar::doCustomizeCommandBar);
+}
+
+//-----------------------------------------------------------------------------
+
+void CommandBar::setCompactPresentation(bool compact) {
+  if (m_compactPresentation == compact || m_compactTransition) return;
+
+  m_compactTransition   = true;
+  m_compactPresentation = compact;
+
+  if (compact) {
+    if (m_compactThreshold <= 0) m_compactThreshold = compactThreshold();
+
+    m_compactActions = actions();
+    m_compactMenu    = new QMenu(this);
+    rebuildCompactMenu();
+
+    for (QAction *action : m_compactActions) removeAction(action);
+
+    m_compactButton = new QToolButton(this);
+    m_compactButton->setObjectName(QStringLiteral("CommandBarCompactButton"));
+    m_compactButton->setArrowType(Qt::DownArrow);
+    m_compactButton->setPopupMode(QToolButton::InstantPopup);
+    m_compactButton->setMenu(m_compactMenu);
+    m_compactButton->setAutoRaise(true);
+    m_compactButton->setFixedSize(kCommandBarCompactButtonSize,
+                                  kCommandBarCompactButtonSize);
+    m_compactButton->setToolTip(tr("Command Bar"));
+    m_compactButton->setContextMenuPolicy(Qt::CustomContextMenu);
+    connect(m_compactButton, &QWidget::customContextMenuRequested, this,
+            [this](const QPoint &pos) {
+              if (m_compactButton)
+                showContextMenu(m_compactButton->mapToGlobal(pos));
+            });
+
+    m_compactWidgetAction = addWidget(m_compactButton);
+  } else {
+    const QList<QAction *> restoreActions = m_compactActions;
+    m_compactActions.clear();
+
+    if (m_compactWidgetAction) {
+      removeAction(m_compactWidgetAction);
+      m_compactWidgetAction->deleteLater();
+      m_compactWidgetAction = nullptr;
+      m_compactButton       = nullptr;
+    }
+    if (m_compactMenu) {
+      m_compactMenu->deleteLater();
+      m_compactMenu = nullptr;
+    }
+
+    for (QAction *action : restoreActions) addAction(action);
+  }
+
+  if (layout()) {
+    layout()->invalidate();
+    layout()->activate();
+  }
+  updateGeometry();
+  m_compactTransition = false;
 }
 
 //-----------------------------------------------------------------------------
@@ -369,6 +561,7 @@ void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
     panel->layout()->invalidate();
     panel->layout()->activate();
   }
+  updateCompactState();
 }
 
 //-----------------------------------------------------------------------------
@@ -377,7 +570,10 @@ void CommandBar::doCustomizeCommandBar() {
   CommandBarPopup *cbPopup = new CommandBarPopup();
 
   if (cbPopup->exec()) {
+    if (m_compactPresentation) setCompactPresentation(false);
     fillToolbar(this);
+    m_compactThreshold = 0;
+    updateCompactState();
   }
   delete cbPopup;
 }

--- a/toonz/sources/toonz/commandbar.cpp
+++ b/toonz/sources/toonz/commandbar.cpp
@@ -1,4 +1,4 @@
-﻿
+
 
 #include "commandbar.h"
 
@@ -7,6 +7,7 @@
 #include "menubarcommandids.h"
 #include "tsystem.h"
 #include "commandbarpopup.h"
+#include "pane.h"
 
 // TnzQt includes
 #include "toonzqt/menubarcommand.h"
@@ -23,6 +24,11 @@
 #include <QtDebug>
 #include <QMenuBar>
 #include <QContextMenuEvent>
+#include <QActionGroup>
+
+namespace {
+constexpr int kCommandBarThickness = 36;
+}
 
 //=============================================================================
 // Toolbar
@@ -30,11 +36,17 @@
 
 CommandBar::CommandBar(QWidget *parent, Qt::WindowFlags flags,
                        bool isCollapsible, bool isXsheetToolbar)
-    : QToolBar(parent), m_isCollapsible(isCollapsible) {
+    : QToolBar(parent)
+    , m_isCollapsible(isCollapsible)
+    , m_isXsheetToolbar(isXsheetToolbar) {
   setObjectName("cornerWidget");
   setObjectName("CommandBar");
   fillToolbar(this, isXsheetToolbar);
   setIconSize(QSize(20, 20));
+
+  connect(this, &QToolBar::orientationChanged, this,
+          &CommandBar::onOrientationChanged);
+  onOrientationChanged(orientation());
 }
 
 //-----------------------------------------------------------------------------
@@ -139,11 +151,129 @@ void CommandBar::buildDefaultToolbar(CommandBar *toolbar) {
 //-----------------------------------------------------------------------------
 
 void CommandBar::contextMenuEvent(QContextMenuEvent *event) {
-  QMenu *menu                  = new QMenu(this);
-  QAction *customizeCommandBar = menu->addAction(tr("Customize Command Bar"));
+  QMenu menu(this);
+  QAction *customizeCommandBar = menu.addAction(tr("Customize Command Bar"));
   connect(customizeCommandBar, SIGNAL(triggered()),
           SLOT(doCustomizeCommandBar()));
-  menu->exec(event->globalPos());
+
+  if (!m_isXsheetToolbar) {
+    menu.addSeparator();
+
+    QMenu *orientationMenu = menu.addMenu(tr("Orientation"));
+    QActionGroup *orientationGroup = new QActionGroup(orientationMenu);
+    orientationGroup->setExclusive(true);
+
+    QAction *horizontalAction = orientationMenu->addAction(tr("Horizontal"));
+    horizontalAction->setCheckable(true);
+    horizontalAction->setChecked(orientation() == Qt::Horizontal);
+    orientationGroup->addAction(horizontalAction);
+
+    QAction *verticalAction = orientationMenu->addAction(tr("Vertical"));
+    verticalAction->setCheckable(true);
+    verticalAction->setChecked(orientation() == Qt::Vertical);
+    orientationGroup->addAction(verticalAction);
+
+    connect(horizontalAction, &QAction::triggered, this,
+            [this]() { setOrientation(Qt::Horizontal); });
+    connect(verticalAction, &QAction::triggered, this,
+            [this]() { setOrientation(Qt::Vertical); });
+  }
+
+  menu.exec(event->globalPos());
+}
+
+//-----------------------------------------------------------------------------
+
+void CommandBar::save(QSettings &settings) const {
+  if (m_isXsheetToolbar) return;
+
+  settings.setValue(QStringLiteral("orientation"),
+                    orientation() == Qt::Vertical
+                        ? QStringLiteral("Vertical")
+                        : QStringLiteral("Horizontal"));
+}
+
+//-----------------------------------------------------------------------------
+
+void CommandBar::load(QSettings &settings) {
+  if (m_isXsheetToolbar) return;
+
+  const QString savedOrientation =
+      settings.value(QStringLiteral("orientation"),
+                     QStringLiteral("Horizontal"))
+          .toString();
+
+  setOrientation(savedOrientation.compare(QStringLiteral("Vertical"),
+                                          Qt::CaseInsensitive) == 0
+                     ? Qt::Vertical
+                     : Qt::Horizontal);
+}
+
+//-----------------------------------------------------------------------------
+
+void CommandBar::onOrientationChanged(Qt::Orientation orientation) {
+  if (m_isXsheetToolbar) return;
+
+  const bool vertical = orientation == Qt::Vertical;
+
+  // The existing Command Bar QSS is horizontally biased. Keep the normal
+  // themed styling for horizontal mode, and use symmetric spacing in vertical
+  // mode so the icons remain centered in a narrow column.
+  if (vertical) {
+    setStyleSheet(
+        "QToolBar#CommandBar { margin: 0; padding: 0; border: 0; }"
+        "QToolBar#CommandBar::separator:vertical {"
+        "  margin: 2px 2px 0 2px;"
+        "}"
+        "QToolBar#CommandBar QToolButton {"
+        "  margin: 2px 0 0 0;"
+        "  padding: 0;"
+        "  min-width: 20px;"
+        "  min-height: 20px;"
+        "}"
+        "QToolBar#CommandBar QToolButton#qt_toolbar_ext_button {"
+        "  margin: 0;"
+        "  padding: 0;"
+        "}");
+  } else {
+    setStyleSheet(QString());
+  }
+
+  // CommandBarPanel is intentionally a very thin wrapper around this toolbar.
+  // Keep its dock/title-bar orientation and fixed thickness synchronized here
+  // so old room layouts need no special-case migration code.
+  TPanel *panel = qobject_cast<TPanel *>(parentWidget());
+  if (!panel) return;
+
+  panel->setOrientation(vertical ? TDockWidget::vertical
+                                 : TDockWidget::horizontal);
+
+  if (vertical) {
+    panel->setMinimumHeight(0);
+    panel->setMaximumHeight(QWIDGETSIZE_MAX);
+    panel->setFixedWidth(kCommandBarThickness);
+
+    // The shipped Command Bar theme constrains its title bar to a narrow left
+    // strip. In vertical mode the title bar moves to the top, so release that
+    // width constraint while retaining the normal 18px title-bar thickness.
+    if (TPanelTitleBar *titleBar = panel->getTitleBar()) {
+      titleBar->setStyleSheet(
+          "TPanelTitleBar {"
+          "  max-width: 16777215;"
+          "  max-height: 18;"
+          "  border-right: 0;"
+          "  border-bottom: 0;"
+          "  border-radius: 0;"
+          "}");
+    }
+  } else {
+    panel->setMinimumWidth(0);
+    panel->setMaximumWidth(QWIDGETSIZE_MAX);
+    panel->setFixedHeight(kCommandBarThickness);
+
+    if (TPanelTitleBar *titleBar = panel->getTitleBar())
+      titleBar->setStyleSheet(QString());
+  }
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/commandbar.h
+++ b/toonz/sources/toonz/commandbar.h
@@ -32,6 +32,7 @@ protected:
   bool m_roomStateLoaded;
   bool m_initialFloatingSizeApplied;
   bool m_userCompact;
+  bool m_autoCompact;
   bool m_compactPresentation;
   bool m_compactTransition;
   bool m_compactUpdatePending;

--- a/toonz/sources/toonz/commandbar.h
+++ b/toonz/sources/toonz/commandbar.h
@@ -35,6 +35,7 @@ protected:
   bool m_autoCompact;
   bool m_compactPresentation;
   bool m_compactTransition;
+  bool m_compactUpdatePending;
   int m_compactThreshold;
   QList<QAction *> m_compactActions;
   QMenu *m_compactMenu;
@@ -59,6 +60,7 @@ protected:
   void showEvent(QShowEvent *event) override;
   void applyInitialFloatingSize();
   void showContextMenu(const QPoint &globalPos);
+  void scheduleCompactUpdate();
   void updateCompactState();
   void setCompactPresentation(bool compact);
   void rebuildCompactMenu();

--- a/toonz/sources/toonz/commandbar.h
+++ b/toonz/sources/toonz/commandbar.h
@@ -5,6 +5,7 @@
 
 #include <memory>
 
+#include "saveloadqsettings.h"
 #include "toonz/txsheet.h"
 #include "toonzqt/keyframenavigator.h"
 
@@ -19,14 +20,18 @@ class QAction;
 // CommandBar
 //-----------------------------------------------------------------------------
 
-class CommandBar : public QToolBar {
+class CommandBar : public QToolBar, public SaveLoadQSettings {
   Q_OBJECT
 protected:
   bool m_isCollapsible;
+  bool m_isXsheetToolbar;
 
 public:
   CommandBar(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags(),
              bool isCollapsible = false, bool isXsheetToolbar = false);
+
+  void save(QSettings &settings) const override;
+  void load(QSettings &settings) override;
 
 signals:
   void updateVisibility();
@@ -38,6 +43,7 @@ protected:
 
 protected slots:
   void doCustomizeCommandBar();
+  void onOrientationChanged(Qt::Orientation orientation);
 };
 
 #endif  // COMMANDBAR_H

--- a/toonz/sources/toonz/commandbar.h
+++ b/toonz/sources/toonz/commandbar.h
@@ -9,12 +9,16 @@
 #include "toonz/txsheet.h"
 #include "toonzqt/keyframenavigator.h"
 
+#include <QList>
 #include <QToolBar>
 
 //-----------------------------------------------------------------------------
 
 // forward declaration
 class QAction;
+class QMenu;
+class QResizeEvent;
+class QToolButton;
 
 //=============================================================================
 // CommandBar
@@ -27,6 +31,15 @@ protected:
   bool m_isXsheetToolbar;
   bool m_roomStateLoaded;
   bool m_initialFloatingSizeApplied;
+  bool m_userCompact;
+  bool m_autoCompact;
+  bool m_compactPresentation;
+  bool m_compactTransition;
+  int m_compactThreshold;
+  QList<QAction *> m_compactActions;
+  QMenu *m_compactMenu;
+  QToolButton *m_compactButton;
+  QAction *m_compactWidgetAction;
 
 public:
   CommandBar(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags(),
@@ -42,8 +55,15 @@ protected:
   static void fillToolbar(CommandBar *toolbar, bool isXsheetToolbar = false);
   static void buildDefaultToolbar(CommandBar *toolbar);
   void contextMenuEvent(QContextMenuEvent *event) override;
+  void resizeEvent(QResizeEvent *event) override;
   void showEvent(QShowEvent *event) override;
   void applyInitialFloatingSize();
+  void showContextMenu(const QPoint &globalPos);
+  void updateCompactState();
+  void setCompactPresentation(bool compact);
+  void rebuildCompactMenu();
+  void setUserCompact(bool compact);
+  int compactThreshold() const;
 
 protected slots:
   void doCustomizeCommandBar();

--- a/toonz/sources/toonz/commandbar.h
+++ b/toonz/sources/toonz/commandbar.h
@@ -25,6 +25,8 @@ class CommandBar : public QToolBar, public SaveLoadQSettings {
 protected:
   bool m_isCollapsible;
   bool m_isXsheetToolbar;
+  bool m_roomStateLoaded;
+  bool m_initialFloatingSizeApplied;
 
 public:
   CommandBar(QWidget *parent = 0, Qt::WindowFlags flags = Qt::WindowFlags(),
@@ -40,6 +42,8 @@ protected:
   static void fillToolbar(CommandBar *toolbar, bool isXsheetToolbar = false);
   static void buildDefaultToolbar(CommandBar *toolbar);
   void contextMenuEvent(QContextMenuEvent *event) override;
+  void showEvent(QShowEvent *event) override;
+  void applyInitialFloatingSize();
 
 protected slots:
   void doCustomizeCommandBar();

--- a/toonz/sources/toonz/commandbar.h
+++ b/toonz/sources/toonz/commandbar.h
@@ -37,6 +37,7 @@ protected:
   bool m_compactTransition;
   bool m_compactUpdatePending;
   int m_compactThreshold;
+  int m_expandedLongSide;
   QList<QAction *> m_compactActions;
   QMenu *m_compactMenu;
   QToolButton *m_compactButton;
@@ -59,6 +60,7 @@ protected:
   void resizeEvent(QResizeEvent *event) override;
   void showEvent(QShowEvent *event) override;
   void applyInitialFloatingSize();
+  void applyCompactPanelSize(bool compact);
   void showContextMenu(const QPoint &globalPos);
   void scheduleCompactUpdate();
   void updateCompactState();

--- a/toonz/sources/toonz/commandbar.h
+++ b/toonz/sources/toonz/commandbar.h
@@ -32,7 +32,6 @@ protected:
   bool m_roomStateLoaded;
   bool m_initialFloatingSizeApplied;
   bool m_userCompact;
-  bool m_autoCompact;
   bool m_compactPresentation;
   bool m_compactTransition;
   bool m_compactUpdatePending;

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -276,8 +276,23 @@ public:
     }
 
     QToolBar *commandBar = qobject_cast<QToolBar *>(widget());
-    if (commandBar && commandBar->orientation() != dockOrientation)
-      commandBar->setOrientation(dockOrientation);
+    if (!commandBar || commandBar->orientation() == dockOrientation) return;
+
+    const int floatingLength =
+        isFloating() ? (commandBar->orientation() == Qt::Horizontal ? width()
+                                                                    : height())
+                     : 0;
+
+    commandBar->setOrientation(dockOrientation);
+
+    if (floatingLength > 0) {
+      QSize panelSize = size();
+      if (dockOrientation == Qt::Vertical)
+        panelSize.setHeight(floatingLength);
+      else
+        panelSize.setWidth(floatingLength);
+      resize(panelSize);
+    }
   }
 };
 

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -248,9 +248,7 @@ class CommandBarPanel final : public TPanel {
 public:
   CommandBarPanel(QWidget *parent);
 
-  // Docking candidates must not be restricted by the Command Bar's current
-  // orientation. The actual fixed thickness is applied when its orientation
-  // is selected for the target docking slot.
+  // Keep docking eligibility independent of current orientation.
   QSize getDockedMinimumSize() override { return QSize(20, 20); }
   QSize getDockedMaximumSize() override {
     return QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
@@ -260,27 +258,26 @@ public:
     DockWidget::selectDockPlaceholder(me);
     if (!m_selectedPlace) return;
 
-    Qt::Orientation targetOrientation;
+    Qt::Orientation dockOrientation;
     switch (m_selectedPlace->getAttribute()) {
     case DockPlaceholder::left:
     case DockPlaceholder::right:
     case DockPlaceholder::sepVert:
-      targetOrientation = Qt::Vertical;
+      dockOrientation = Qt::Vertical;
       break;
     case DockPlaceholder::top:
     case DockPlaceholder::bottom:
     case DockPlaceholder::sepHor:
-      targetOrientation = Qt::Horizontal;
+      dockOrientation = Qt::Horizontal;
       break;
+    case DockPlaceholder::root:
     default:
-      // A root placeholder has no directional preference. Keep the user's
-      // current floating orientation in that case.
       return;
     }
 
-    QToolBar *toolbar = qobject_cast<QToolBar *>(widget());
-    if (toolbar && toolbar->orientation() != targetOrientation)
-      toolbar->setOrientation(targetOrientation);
+    QToolBar *commandBar = qobject_cast<QToolBar *>(widget());
+    if (commandBar && commandBar->orientation() != dockOrientation)
+      commandBar->setOrientation(dockOrientation);
   }
 };
 

--- a/toonz/sources/toonz/tpanels.h
+++ b/toonz/sources/toonz/tpanels.h
@@ -14,6 +14,9 @@
 #include "toonz/tstageobjectid.h"
 #include "toonzqt/colorfield.h"
 #include "toonzqt/functionviewer.h"
+
+#include <QToolBar>
+
 class PaletteViewer;
 class TPaletteHandle;
 class StyleEditor;
@@ -242,10 +245,43 @@ public:
 class CommandBarPanel final : public TPanel {
   Q_OBJECT
 
-  // ToolOptions *m_toolOption;
-
 public:
   CommandBarPanel(QWidget *parent);
+
+  // Docking candidates must not be restricted by the Command Bar's current
+  // orientation. The actual fixed thickness is applied when its orientation
+  // is selected for the target docking slot.
+  QSize getDockedMinimumSize() override { return QSize(20, 20); }
+  QSize getDockedMaximumSize() override {
+    return QSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
+  }
+
+  void selectDockPlaceholder(QMouseEvent *me) override {
+    DockWidget::selectDockPlaceholder(me);
+    if (!m_selectedPlace) return;
+
+    Qt::Orientation targetOrientation;
+    switch (m_selectedPlace->getAttribute()) {
+    case DockPlaceholder::left:
+    case DockPlaceholder::right:
+    case DockPlaceholder::sepVert:
+      targetOrientation = Qt::Vertical;
+      break;
+    case DockPlaceholder::top:
+    case DockPlaceholder::bottom:
+    case DockPlaceholder::sepHor:
+      targetOrientation = Qt::Horizontal;
+      break;
+    default:
+      // A root placeholder has no directional preference. Keep the user's
+      // current floating orientation in that case.
+      return;
+    }
+
+    QToolBar *toolbar = qobject_cast<QToolBar *>(widget());
+    if (toolbar && toolbar->orientation() != targetOrientation)
+      toolbar->setOrientation(targetOrientation);
+  }
 };
 
 //=========================================================


### PR DESCRIPTION
## Summary

Allows the Command Bar to work horizontally or vertically and automatically match the docking location.

## Behavior

- Left/right docks -> Vertical.
- Top/bottom docks -> Horizontal.
- Floating bars can be switched manually.
- **Compact** reduces the bar to one menu control while keeping all configured commands available.
- Compact also activates automatically when there is not enough room to show multiple commands inline.
- Explicit Compact state and orientation persist with the room.
- New floating Command Bars start at about half the available screen along their long axis.

The Xsheet Toolbar is unchanged.

## Test

- Horizontal/vertical docking and repeated auto-rotation.
- Compact on/off in both orientations.
- Shrink a normal bar until it enters Compact, then enlarge it and confirm normal presentation returns.
- Run commands from the Compact menu.
- Save/reload rooms with Compact enabled.
- Check overflow controls, grip geometry, spacing, and HiDPI appearance.