### PR TITLE
[Try Fix] Prevent room startup crash when a saved custom panel is missing

### DIFF
--- a/toonz/sources/toonz/pane.cpp
+++ b/toonz/sources/toonz/pane.cpp
@@ -34,6 +34,7 @@
 #include <QTextEdit>
 #include <QScreen>
 #include <QGlobalStatic>
+#include <QDebug>
 #include <memory>
 #include <utility>
 
@@ -956,8 +957,13 @@ TPanel *TPanelFactory::createPanel(QWidget *parent, const QString &panelType) {
 
   if (panelType.startsWith(QStringLiteral("Custom_"))) {
     QString customType = panelType.mid(7);
-    return CustomPanelManager::instance()->createCustomPanel(customType,
-                                                             parent);
+    if (TPanel *panel =
+            CustomPanelManager::instance()->createCustomPanel(customType,
+                                                              parent))
+      return panel;
+
+    qWarning() << "TPanelFactory::createPanel: unable to create custom panel"
+               << panelType << "- using generic fallback";
   }
 
   // Fallback: generic panel


### PR DESCRIPTION
## Try Fix / investigation

Related to upstream issue opentoonz/opentoonz#6845.

The reporter found that restoring the old `layouts/rooms` data onto an otherwise clean layout makes the startup crash return. That makes room deserialization the strongest reproducible clue in the report.

During `Room::load()`, OpenToonz creates a panel from the saved `pane_N/name` and then accesses `pane->widget()` before reaching the existing `if (!pane)` fallback. Current `TPanelFactory::createPanel()` already creates a generic fallback for ordinary unknown panel names, but the `Custom_*` path returns the result of `CustomPanelManager::createCustomPanel()` directly. If that saved custom panel no longer exists or cannot be created, a null pointer can therefore reach `Room::load()`.

### Change

- Check the result of `createCustomPanel()` before returning it.
- If custom-panel creation succeeds, behavior is unchanged.
- If it fails, emit a warning identifying the saved panel type.
- Fall through to the existing generic-panel fallback instead of returning null.

This is intentionally narrow: normal/native panel creation and successful custom-panel creation are unchanged.

### Suggested reproduction

1. Start with a known-good room `.ini`.
2. Add or change one `pane_N/name` entry to a nonexistent custom panel such as `Custom_DefinitelyNotARealPanel`.
3. Restart OpenToonz with that room active.

Expected with this change: startup should avoid the null-pointer path, load a generic fallback panel, and log the missing `Custom_*` panel identifier.

### Investigation status

This does **not** claim that the original #6845 root cause is confirmed. The reporter's original room data would still be the best verification case. This PR is intended to make the most concrete remaining null-return path non-fatal and give us a specific behavior to test.

I could not compile/run the Windows application in this editing environment, so CI and contributor testing are requested.