### PR TITLE
Test Studio Palette lifetime fix for upstream #5065

### DIFF
--- a/toonz/sources/toonzlib/studiopalettecmd.cpp
+++ b/toonz/sources/toonzlib/studiopalettecmd.cpp
@@ -480,7 +480,11 @@ void adaptLevelToPalette(TXshLevelHandle *currentLevelHandle,
   TXshSimpleLevel *sl = currentLevelHandle->getSimpleLevel();
   QApplication::setOverrideCursor(Qt::WaitCursor);
 
-  TPalette *oldPalette = sl->getPalette();
+  // Keep the current level palette alive for the duration of the operation.
+  // The palette handle stores only a raw pointer, while the level and images
+  // release their owning references as they switch to the Studio Palette.
+  TPaletteP oldPalette = sl->getPalette();
+  std::wstring oldGlobalName = paletteHandle->getPalette()->getGlobalName();
 
   ToleranceMap.clear();
 
@@ -507,7 +511,6 @@ void adaptLevelToPalette(TXshLevelHandle *currentLevelHandle,
 
   currentLevelHandle->getSimpleLevel()->setPalette(plt);
 
-  std::wstring oldGlobalName = paletteHandle->getPalette()->getGlobalName();
   paletteHandle->setPalette(plt);
   paletteHandle->getPalette()->setGlobalName(oldGlobalName);
   plt->setDirtyFlag(true);


### PR DESCRIPTION
## Summary

This is a narrow test patch for the crash reported upstream in:

https://github.com/opentoonz/opentoonz/issues/5065

The report describes preview/render crashing after using a Studio Palette to replace/adjust a level palette, with the failure eventually appearing in `TMacroFx::clone()` during render-tree construction.

While tracing the Studio Palette path, `adaptLevelToPalette()` was found to contain a palette-lifetime hazard:

- `TPaletteHandle` stores a raw `TPalette*`.
- The level owns its palette through `TPaletteP`.
- Each image also reference-counts its palette.
- During `Adjust Current Level to This Palette`, the images and level switch to the new Studio Palette before the code reads the old palette's global name through the palette handle.
- If those owning references were the last references to the old palette, the handle could temporarily point at an object that has already been released.

## What this PR does

- Keeps the old level palette alive for the duration of `adaptLevelToPalette()` by holding it in a `TPaletteP` instead of a raw pointer.
- Captures the old palette global name before the images and level release their references to that palette.
- Leaves the existing palette replacement, raster index adaptation, notifications, undo behavior, and Studio Palette linking behavior unchanged.

This is intentionally the smallest change needed to remove the identified lifetime hazard and make the #5065 reproduction worth retesting.

## What this PR expressly does not do

This PR does **not** claim that the lifetime hazard is definitively the sole cause of #5065.

It does **not**:

- change `TMacroFx::clone()`;
- change render-tree construction;
- change the Color Blending FX;
- change how palette indexes are remapped;
- preserve the original level palette object by assigning Studio Palette contents in place;
- redesign palette ownership or convert `TPaletteHandle` to a smart pointer;
- attempt to fix other palette-pointer issues outside `adaptLevelToPalette()`.

If the original crash still reproduces with this patch, the next investigation should instrument the `TMacroFx::clone()` path separately rather than broadening this patch.

## Requested testing

Please try the original #5065 workflow, especially:

1. Use **Adjust Current Level to This Palette** on a Toonz Raster level.
2. Preview/render.
3. Adjust the level to a Studio Palette a second time.
4. Preview/render again.
5. Repeat with the reported Color Blending FX enabled.
6. Compare with the same test with Color Blending disabled.

It is also useful to compare **Adjust Current Level to This Palette** with **Load into Current Palette**, since the latter modifies the existing palette in place and follows a different code path.

## Scope

One file changed:

`toonz/sources/toonzlib/studiopalettecmd.cpp`

The functional diff is limited to retaining the old palette through a smart pointer and moving the global-name read before palette replacement.