### PR TITLE
Recognize hyphen-separated image sequences

### DIFF
--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -106,6 +106,20 @@ bool parseFrame(const std::wstring &str, int &frame, QString &letter,
   return true;
 }
 
+// Returns the separator that may precede a frame number. Preserve the legacy
+// priority for '.', otherwise use the rightmost supported alternative. Hyphen
+// is always recognized; underscore remains controlled by the project setting.
+int rfindFrameSep(const std::wstring &str, int i, bool underscoreAllowed) {
+  std::wstring head = str.substr(0, i);
+  int j             = (int)head.rfind(L'.');
+  if (j != (int)std::wstring::npos) return j;
+
+  int jh = (int)head.rfind(L'-');
+  int ju = underscoreAllowed ? (int)head.rfind(L'_')
+                             : (int)std::wstring::npos;
+  return jh > ju ? jh : ju;
+}
+
 };  // namespace
 
 TFrameId::TFrameId(const std::string &str, char s)
@@ -381,7 +395,7 @@ bool TFilePath::operator<(const TFilePath &fp) const {
   }
   while (i2 != -1 || j2 != -1) {
     iName = (i2 != -1) ? m_path.substr(i1, i2 - i1) : m_path;
-    jName = (j2 != -1) ? fp.m_path.substr(j1, j2 - j1) : fp.m_path;
+    jName = (j2 != -1) ? m_path.substr(j1, j2 - j1) : fp.m_path;
 // if the two path parts, between slashes, are equal
 // iterate the comparison process otherwise return
 #ifdef _WIN32
@@ -401,7 +415,7 @@ bool TFilePath::operator<(const TFilePath &fp) const {
   iName = m_path.substr(i1, m_path.size() - i1);
   jName = fp.m_path.substr(j1, fp.m_path.size() - j1);
 #ifdef _WIN32
-  return _wcsicmp(iName.c_str(), jName.c_str()) < 0;
+  return _wcsicmp(iName.c_str(), fp.m_path.substr(j1, fp.m_path.size() - j1).c_str()) < 0;
 #else
   return TFilePath(iName) < TFilePath(jName);
 #endif
@@ -577,7 +591,7 @@ std::string TFilePath::getDots() const {
     TFilePathInfo info = analyzePath();
     if (info.extension.isEmpty()) return "";
     if (info.sepChar.isNull()) return ".";
-    // return ".." regardless of sepChar type (either "_" or ".")
+    // return ".." regardless of separator type
     return "..";
   }
   //-----
@@ -590,9 +604,7 @@ std::string TFilePath::getDots() const {
   i = str.rfind(L".");
   if (i == (int)std::wstring::npos || str == L"..") return "";
 
-  int j = str.substr(0, i).rfind(L".");
-  if (j == (int)std::wstring::npos && m_underscoreFormatAllowed)
-    j = str.substr(0, i).rfind(L"_");
+  int j = rfindFrameSep(str, i, m_underscoreFormatAllowed);
 
   if (j != (int)std::wstring::npos)
     return (j == i - 1 || (checkForSeqNum(type) && isNumbers(str, j, i))) ? ".."
@@ -614,21 +626,12 @@ QChar TFilePath::getSepChar() const {
   i = str.rfind(L".");
   if (i == (int)std::wstring::npos || str == L"..") return QChar();
 
-  int j = str.substr(0, i).rfind(L".");
+  int j = rfindFrameSep(str, i, m_underscoreFormatAllowed);
+  if (j == (int)std::wstring::npos) return QChar();
 
-  if (j != (int)std::wstring::npos)
-    return (j == i - 1 || (checkForSeqNum(type) && isNumbers(str, j, i)))
-               ? QChar('.')
-               : QChar();
-  if (!m_underscoreFormatAllowed) return QChar();
-
-  j = str.substr(0, i).rfind(L"_");
-  if (j != (int)std::wstring::npos)
-    return (j == i - 1 || (checkForSeqNum(type) && isNumbers(str, j, i)))
-               ? QChar('_')
-               : QChar();
-  else
-    return QChar();
+  if (j == i - 1 || (checkForSeqNum(type) && isNumbers(str, j, i)))
+    return QChar(str[j]);
+  return QChar();
 }
 
 //-----------------------------------------------------------------------------
@@ -682,15 +685,10 @@ std::wstring TFilePath::getWideName() const  // noDot! noSlash!
   std::wstring str = m_path.substr(i + 1);
   i                = str.rfind(L".");
   if (i == (int)std::wstring::npos) return str;
-  int j = str.substr(0, i).rfind(L".");
-  if (j != (int)std::wstring::npos) {
-    if (checkForSeqNum(type) && isNumbers(str, j, i)) i = j;
-  } else if (m_underscoreFormatAllowed) {
-    j = str.substr(0, i).rfind(L"_");
-    if (j != (int)std::wstring::npos && checkForSeqNum(type) &&
-        isNumbers(str, j, i))
-      i = j;
-  }
+  int j = rfindFrameSep(str, i, m_underscoreFormatAllowed);
+  if (j != (int)std::wstring::npos && checkForSeqNum(type) &&
+      isNumbers(str, j, i))
+    i = j;
   return str.substr(0, i);
 }
 
@@ -726,9 +724,7 @@ std::wstring TFilePath::getLevelNameW() const {
   if (isFfmpegType()) return str;
   int j = str.rfind(L".");                       // str[j..] = ".type"
   if (j == (int)std::wstring::npos) return str;  // no frame; no type
-  i = str.substr(0, j).rfind(L'.');
-  if (i == (int)std::wstring::npos && m_underscoreFormatAllowed)
-    i = str.substr(0, j).rfind(L'_');
+  i = rfindFrameSep(str, j, m_underscoreFormatAllowed);
 
   if (j == i || j - i == 1)  // prova.tif or prova..tif
     return str;
@@ -787,17 +783,13 @@ TFrameId TFilePath::getFrame() const {
   i                = str.rfind(L'.');
   if (i == (int)std::wstring::npos || str == L"." || str == L"..")
     return TFrameId(TFrameId::NO_FRAME);
-  int j;
 
-  j = str.substr(0, i).rfind(L'.');
-  if (j == (int)std::wstring::npos && m_underscoreFormatAllowed)
-    j = str.substr(0, i).rfind(L'_');
+  int j = rfindFrameSep(str, i, m_underscoreFormatAllowed);
 
   if (j == (int)std::wstring::npos) return TFrameId(TFrameId::NO_FRAME);
   if (i == j + 1) return TFrameId(TFrameId::EMPTY_FRAME);
 
-  // Exclude cases with non-numeric characters inbetween. (In case the file name
-  // contains "_" or ".")
+  // Exclude cases with non-numeric characters between separator and extension.
   if (!checkForSeqNum(type) || !isNumbers(str, j, i))
     return TFrameId(TFrameId::NO_FRAME);
 
@@ -888,9 +880,7 @@ TFilePath TFilePath::withName(const std::wstring &name) const {
   }
   int k;
 
-  k = str.substr(0, j).rfind(L".");
-  if (k == (int)std::wstring::npos && m_underscoreFormatAllowed)
-    k = str.substr(0, j).rfind(L"_");
+  k = rfindFrameSep(str, j, m_underscoreFormatAllowed);
 
   if (k == (int)(std::wstring::npos))
     k = j;
@@ -956,6 +946,17 @@ TFilePath TFilePath::withFrame(const TFrameId &frame,
                                     format == TFrameId::UNDERSCORE_CUSTOM_PAD))
     ch = "_";
 
+  // Preserve a hyphen separator from the source path when addressing sibling
+  // frames. TFrameId currently groups all non-dot separators with underscore
+  // formats, so this explicit check prevents '-' from being rewritten as '_'.
+  if (j != (int)std::wstring::npos) {
+    int srcSep = rfindFrameSep(str, j, m_underscoreFormatAllowed);
+    if (srcSep != (int)std::wstring::npos && str[srcSep] == L'-' &&
+        (srcSep == j - 1 ||
+         (checkForSeqNum(type) && isNumbers(str, srcSep, j))))
+      ch = "-";
+  }
+
   // no extension case
   if (j == (int)std::wstring::npos) {
     if (frame.isEmptyFrame() || frame.isNoFrame())
@@ -964,11 +965,15 @@ TFilePath TFilePath::withFrame(const TFrameId &frame,
       return TFilePath(m_path + ::to_wstring(ch + frame.expand(format)));
   }
 
-  int k = str.substr(0, j).rfind(L'.');
+  int k = rfindFrameSep(str, j, m_underscoreFormatAllowed);
 
   bool hasValidFrameNum = false;
-  if (!isFfmpegType() && checkForSeqNum(type) && isNumbers(str, k, j))
-    hasValidFrameNum = true;
+  if (!isFfmpegType() && checkForSeqNum(type)) {
+    if (isNumbers(str, k, j))
+      hasValidFrameNum = true;
+    else
+      k = (int)std::wstring::npos;
+  }
   std::string frameString;
   if (frame.isNoFrame())
     frameString = "";
@@ -1113,14 +1118,14 @@ TFilePath::TFilePathInfo TFilePath::analyzePath() const {
 
   QString fileName = QString::fromStdWString(str);
 
-  // Level Name : letters other than  \/:,;*?"<>|
+  // Level Name : letters other than  \\/:,;*?"<>|
   const QString levelNameRegExp("([^\\\\/:,;*?\"<>|]+)");
-  // Sep Char : period or underscore
-  const QString sepCharRegExp("([\\._])");
+  // Sep Char : period, underscore or hyphen
+  const QString sepCharRegExp("([\\._-])");
   // Frame Number and Suffix
   QString fIdRegExp = TFilePath::fidRegExpStr();
 
-  // Extension: letters other than "._" or  \/:,;*?"<>|  or " "(space)
+  // Extension: letters other than "._" or  \\/:,;*?"<>|  or " "(space)
   const QString extensionRegExp("([^\\._ \\\\/:,;*?\"<>|]+)");
 
   // Modern QRegularExpression implementation

--- a/toonz/sources/common/tsystem/tfilepath.cpp
+++ b/toonz/sources/common/tsystem/tfilepath.cpp
@@ -395,7 +395,7 @@ bool TFilePath::operator<(const TFilePath &fp) const {
   }
   while (i2 != -1 || j2 != -1) {
     iName = (i2 != -1) ? m_path.substr(i1, i2 - i1) : m_path;
-    jName = (j2 != -1) ? m_path.substr(j1, j2 - j1) : fp.m_path;
+    jName = (j2 != -1) ? fp.m_path.substr(j1, j2 - j1) : fp.m_path;
 // if the two path parts, between slashes, are equal
 // iterate the comparison process otherwise return
 #ifdef _WIN32
@@ -415,7 +415,7 @@ bool TFilePath::operator<(const TFilePath &fp) const {
   iName = m_path.substr(i1, m_path.size() - i1);
   jName = fp.m_path.substr(j1, fp.m_path.size() - j1);
 #ifdef _WIN32
-  return _wcsicmp(iName.c_str(), fp.m_path.substr(j1, fp.m_path.size() - j1).c_str()) < 0;
+  return _wcsicmp(iName.c_str(), jName.c_str()) < 0;
 #else
   return TFilePath(iName) < TFilePath(jName);
 #endif
@@ -591,7 +591,7 @@ std::string TFilePath::getDots() const {
     TFilePathInfo info = analyzePath();
     if (info.extension.isEmpty()) return "";
     if (info.sepChar.isNull()) return ".";
-    // return ".." regardless of separator type
+    // return ".." regardless of separator type (".", "_" or "-")
     return "..";
   }
   //-----
@@ -1118,14 +1118,14 @@ TFilePath::TFilePathInfo TFilePath::analyzePath() const {
 
   QString fileName = QString::fromStdWString(str);
 
-  // Level Name : letters other than  \\/:,;*?"<>|
+  // Level Name : letters other than  \/:,;*?"<>|
   const QString levelNameRegExp("([^\\\\/:,;*?\"<>|]+)");
   // Sep Char : period, underscore or hyphen
   const QString sepCharRegExp("([\\._-])");
   // Frame Number and Suffix
   QString fIdRegExp = TFilePath::fidRegExpStr();
 
-  // Extension: letters other than "._" or  \\/:,;*?"<>|  or " "(space)
+  // Extension: letters other than "._" or  \/:,;*?"<>|  or " "(space)
   const QString extensionRegExp("([^\\._ \\\\/:,;*?\"<>|]+)");
 
   // Modern QRegularExpression implementation

--- a/toonz/sources/include/tfilepath.h
+++ b/toonz/sources/include/tfilepath.h
@@ -146,7 +146,7 @@ class DVAPI TFilePath {
   struct TFilePathInfo {
     QString parentDir;  // with slash
     QString levelName;
-    QChar sepChar;  // either "." or "_"
+    QChar sepChar;  // ".", "_" or "-"
     TFrameId fId;
     QString extension;
   };


### PR DESCRIPTION
## Summary

Prepare a focused port of Ztoryc's upstream candidate for recognizing `-` (hyphen) as an image-sequence frame separator.

Source candidate:
- `matitanimata/ztoryc` — **File handling: Image-sequence recognition with `-` (hyphen) separator**
- Example: `frame-0006.jpg`

Related OpenToonz filename tracking: opentoonz/opentoonz#1928

## What this changes

OpenToonz currently recognizes `.` as the primary frame separator and optionally `_`. This adapts Ztoryc's separator handling to current OT-Dev code so a hyphen can also be recognized when it immediately precedes a valid image frame id.

The port keeps the relevant `TFilePath` operations consistent:

- sequence detection (`getDots()` / `getSepChar()`)
- level-name extraction (`getWideName()` / `getLevelNameW()`)
- frame-id extraction (`getFrame()`)
- level renaming (`withName()`)
- sibling-frame path generation (`withFrame()`)
- custom/non-standard path parsing (`analyzePath()`)

`withFrame()` explicitly preserves an existing `-` separator. This is needed because the current `TFrameId` format classification treats non-dot separators like underscore formats and would otherwise generate `_` when addressing another frame.

## Guardrails / compatibility

This is intentionally narrower than a general filename grammar change.

- `frame-0006.jpg` is recognized as a sequence frame.
- `frame-0006a.jpg` continues to use the existing optional frame-letter support.
- `my-file.jpg` remains an ordinary single image because the text after `-` is not a valid frame id.
- Sequence recognition remains limited by the existing `checkForSeqNum()` image-type check.
- Existing `.` precedence is retained. A name such as `shot.v2-0006.jpg` is therefore **not** newly reinterpreted by this port.
- Existing project control over `_` remains unchanged; `-` support does not depend on the underscore preference.

## How this fits current OpenToonz

This is not a replacement for the filename work already merged upstream:

- #1833 broadened core parsing beyond exactly four digits and added/fixed optional number+letter handling.
- #2607 allowed sequences beginning with frame 0.
- #5768 added a normalization/rename path for image sequences whose numeric suffix is not already expressed in OpenToonz's recognized separator form.

Direct recognition of `name-0001.ext` complements #5768: common exporter-native hyphenated sequences should be usable directly rather than first requiring physical filename normalization.

## Relationship to #1928

Shun's opentoonz/opentoonz#1928 identifies a broader class of filename/frame-id inconsistencies across UI entry fields, Flipbook, conversion tools, sequence ranges, suffix letters, padding and related paths.

This PR should **not** close #1928. It is best treated as one parser-level interoperability improvement that makes the core path model more consistent. Remaining #1928 items should be evaluated independently so UI/conversion behavior is not bundled into this port.

## Validation targets

Expected behavior to verify in File Browser / Load Level and normal level access:

- [ ] `frame-0001.jpg`, `frame-0002.jpg` group as one level
- [ ] `frame-0001a.jpg` preserves the optional letter frame id
- [ ] sibling frame lookup preserves `-` rather than generating `_`
- [ ] `my-file.jpg` remains a single file
- [ ] existing `frame.0001.jpg` behavior is unchanged
- [ ] existing `frame_0001.jpg` behavior is unchanged when underscore format is enabled
- [ ] non-sequential/movie extensions are not reinterpreted as image sequences
- [ ] custom/non-standard filename parsing recognizes `-` consistently

## Notes

This is an adapted port, not a wholesale copy of Ztoryc's `tfilepath.cpp`. Ztoryc has unrelated divergence in the same file (including older Qt regex code and other file-type behavior), so only the hyphen-separator logic has been carried into current OT-Dev.

Local compilation was not available in this connector-only staging pass; CI and runtime sequence tests are still required before marking the PR ready.