### PR TITLE
Add translation validation and coverage reporting

### DIFF
--- a/.github/workflows/translation_validation.yml
+++ b/.github/workflows/translation_validation.yml
@@ -1,0 +1,439 @@
+name: Translation Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  translation-validation:
+    name: Translation Validation
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          lfs: false
+
+      - name: Detect translation state
+        id: translations
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          PUSH_BASE: ${{ github.event.before }}
+          PUSH_HEAD: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          translation_root="toonz/sources/translations"
+          workflow_path=".github/workflows/translation_validation.yml"
+
+          is_translation_ts() {
+            local path="$1"
+            [[ "$path" == "$translation_root/"* && "$path" == *.ts ]]
+          }
+
+          is_validation_workflow() {
+            [[ "$1" == "$workflow_path" ]]
+          }
+
+          present=false
+          if [[ -d "$translation_root" ]]; then
+            while IFS= read -r -d '' ts; do
+              present=true
+              break
+            done < <(
+              find "$translation_root" \
+                -type f \
+                -name '*.ts' \
+                -print0 \
+                -quit
+            )
+          fi
+
+          changed=false
+          workflow_changed=false
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            # A manual run is an explicit request for a full translation scan.
+            changed="$present"
+          else
+            if [[ "$EVENT_NAME" == "pull_request" ]]; then
+              diff_args=("$PR_BASE...$PR_HEAD")
+            else
+              diff_args=("$PUSH_BASE" "$PUSH_HEAD")
+            fi
+
+            diff_file="$RUNNER_TEMP/translation-paths.diff"
+
+            git diff \
+              --name-status \
+              --find-renames \
+              -z \
+              "${diff_args[@]}" \
+              > "$diff_file"
+
+            while IFS= read -r -d '' status; do
+              if ! IFS= read -r -d '' path1; then
+                echo "::error title=Translation detection error::Malformed git diff record."
+                exit 1
+              fi
+
+              path2=""
+
+              case "$status" in
+                R*)
+                  if ! IFS= read -r -d '' path2; then
+                    echo "::error title=Translation detection error::Malformed rename record."
+                    exit 1
+                  fi
+
+                  if is_translation_ts "$path1" || is_translation_ts "$path2"; then
+                    changed=true
+                  fi
+
+                  if is_validation_workflow "$path1" || is_validation_workflow "$path2"; then
+                    workflow_changed=true
+                  fi
+                  ;;
+
+                C*)
+                  if ! IFS= read -r -d '' path2; then
+                    echo "::error title=Translation detection error::Malformed copy record."
+                    exit 1
+                  fi
+
+                  # A copy changes only the destination path.
+                  if is_translation_ts "$path2"; then
+                    changed=true
+                  fi
+
+                  if is_validation_workflow "$path2"; then
+                    workflow_changed=true
+                  fi
+                  ;;
+
+                *)
+                  if is_translation_ts "$path1"; then
+                    changed=true
+                  fi
+
+                  if is_validation_workflow "$path1"; then
+                    workflow_changed=true
+                  fi
+                  ;;
+              esac
+            done < "$diff_file"
+
+            # Workflow changes test themselves by forcing one full scan.
+            if [[ "$workflow_changed" == "true" && "$present" == "true" ]]; then
+              changed=true
+            fi
+          fi
+
+          should_run=false
+          if [[ "$changed" == "true" && "$present" == "true" ]]; then
+            should_run=true
+          fi
+
+          {
+            echo "present=$present"
+            echo "changed=$changed"
+            echo "workflow_changed=$workflow_changed"
+            echo "should_run=$should_run"
+          } >> "$GITHUB_OUTPUT"
+
+          if [[ "$present" == "true" ]]; then
+            echo "Translation catalogs are present."
+          else
+            echo "Repository contains zero .ts files."
+          fi
+
+          if [[ "$should_run" == "true" ]]; then
+            if [[ "$workflow_changed" == "true" ]]; then
+              echo "Translation workflow changed; running a full validation scan."
+            else
+              echo "Translation paths changed; running validation."
+            fi
+          else
+            echo "No lrelease work is required."
+          fi
+
+      - name: Install Qt Linguist tools
+        if: steps.translations.outputs.should_run == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qttools5-dev-tools
+
+      - name: Validate all translation catalogs with lrelease
+        if: steps.translations.outputs.should_run == 'true'
+        shell: bash
+        run: |
+          set -uo pipefail
+
+          translation_root="toonz/sources/translations"
+          failed=0
+          count=0
+
+          escape_property() {
+            local value="$1"
+            value="${value//'%'/'%25'}"
+            value="${value//$'\r'/'%0D'}"
+            value="${value//$'\n'/'%0A'}"
+            value="${value//':'/'%3A'}"
+            value="${value//','/'%2C'}"
+            printf '%s' "$value"
+          }
+
+          while IFS= read -r -d '' ts; do
+            count=$((count + 1))
+            printf 'Checking %q\n' "$ts"
+
+            output="$(
+              lrelease "$ts" \
+                -qm "$RUNNER_TEMP/translation-check.qm" \
+                2>&1
+            )"
+            status=$?
+
+            printf '%s\n' "$output"
+
+            if (( status != 0 )); then
+              annotated=0
+
+              while IFS= read -r line; do
+                if [[ "$line" =~ :([0-9]+):([0-9]+)$ ]]; then
+                  lineno="${BASH_REMATCH[1]}"
+                  col="${BASH_REMATCH[2]}"
+                  safe_file="$(escape_property "$ts")"
+
+                  message="${line#lrelease error: }"
+                  message="${message//'%'/'%25'}"
+                  message="${message//$'\r'/'%0D'}"
+                  message="${message//$'\n'/'%0A'}"
+
+                  echo "::error file=$safe_file,line=$lineno,col=$col,title=Invalid Qt translation::$message"
+                  annotated=1
+                fi
+              done <<< "$output"
+
+              if (( annotated == 0 )); then
+                safe_file="$(escape_property "$ts")"
+                echo "::error file=$safe_file,title=Invalid Qt translation::lrelease failed; see job log."
+              fi
+
+              failed=1
+            fi
+          done < <(
+            find "$translation_root" \
+              -type f \
+              -name '*.ts' \
+              -print0
+          )
+
+          echo "Checked $count translation files."
+          exit "$failed"
+
+      - name: Report untranslated and unfinished entries
+        if: always() && steps.translations.outputs.should_run == 'true'
+        continue-on-error: true
+        shell: bash
+        run: |
+          python3 <<'PY'
+          import json
+          from pathlib import Path
+          import xml.etree.ElementTree as ET
+
+          translation_root = Path("toonz/sources/translations")
+          jsonl_path = Path("translation-coverage.jsonl")
+          markdown_path = Path("translation-coverage.md")
+
+          records = []
+          stats = []
+
+          def text_of(element):
+              if element is None:
+                  return ""
+              return "".join(element.itertext()).strip()
+
+          for path in sorted(translation_root.rglob("*.ts"), key=lambda p: p.as_posix()):
+              try:
+                  root = ET.parse(path).getroot()
+              except Exception as exc:
+                  # lrelease remains the hard validator. Coverage reporting is informational.
+                  records.append({
+                      "file": path.as_posix(),
+                      "language": "",
+                      "context": "",
+                      "status": "coverage_parse_error",
+                      "source": "",
+                      "detail": str(exc),
+                  })
+                  stats.append((path.as_posix(), 0, 0, 0, 0, 0, 1))
+                  continue
+
+              language = root.get("language", "")
+              active = complete = untranslated = unfinished = incomplete_plural = 0
+
+              for context in root.findall("context"):
+                  context_name = context.findtext("name", default="")
+
+                  for message in context.findall("message"):
+                      translation = message.find("translation")
+
+                      if translation is not None and translation.get("type") in {"obsolete", "vanished"}:
+                          continue
+
+                      active += 1
+                      source = message.findtext("source", default="")
+                      status = None
+
+                      if translation is None:
+                          status = "untranslated"
+
+                      elif translation.get("type") == "unfinished":
+                          status = "unfinished"
+
+                      elif message.get("numerus") == "yes":
+                          forms = translation.findall("numerusform")
+                          if not forms or any(not text_of(form) for form in forms):
+                              status = "incomplete_plural"
+
+                      elif not text_of(translation):
+                          status = "untranslated"
+
+                      if status is None:
+                          complete += 1
+                          continue
+
+                      if status == "unfinished":
+                          unfinished += 1
+                      elif status == "incomplete_plural":
+                          incomplete_plural += 1
+                      else:
+                          untranslated += 1
+
+                      records.append({
+                          "file": path.as_posix(),
+                          "language": language,
+                          "context": context_name,
+                          "status": status,
+                          "source": source,
+                      })
+
+              stats.append((
+                  path.as_posix(),
+                  active,
+                  complete,
+                  untranslated,
+                  unfinished,
+                  incomplete_plural,
+                  0,
+              ))
+
+          with jsonl_path.open("w", encoding="utf-8") as out:
+              for record in records:
+                  out.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+          total_active = sum(row[1] for row in stats)
+          total_complete = sum(row[2] for row in stats)
+          total_untranslated = sum(row[3] for row in stats)
+          total_unfinished = sum(row[4] for row in stats)
+          total_incomplete = sum(row[5] for row in stats)
+          total_parse_errors = sum(row[6] for row in stats)
+
+          lines = [
+              "## Translation Coverage",
+              "",
+              "This report is informational and does **not** fail Translation Validation.",
+              "",
+              "| Catalog | Active | Complete | Untranslated | Unfinished | Incomplete plural |",
+              "|---|---:|---:|---:|---:|---:|",
+          ]
+
+          for path, active, complete, untranslated, unfinished, incomplete, parse_errors in stats:
+              display_path = json.dumps(path, ensure_ascii=False)
+              if parse_errors:
+                  lines.append(
+                      f"| `{display_path}` | — | — | — | — | — |"
+                  )
+              else:
+                  lines.append(
+                      f"| `{display_path}` | {active} | {complete} | "
+                      f"{untranslated} | {unfinished} | {incomplete} |"
+                  )
+
+          lines.extend([
+              "",
+              f"**Active messages:** {total_active}",
+              f"**Complete translations:** {total_complete}",
+              f"**Untranslated:** {total_untranslated}",
+              f"**Unfinished:** {total_unfinished}",
+              f"**Incomplete plural forms:** {total_incomplete}",
+          ])
+
+          if total_parse_errors:
+              lines.append(f"**Coverage parse errors:** {total_parse_errors}")
+
+          actionable = total_untranslated + total_unfinished + total_incomplete
+
+          if actionable:
+              lines.extend([
+                  "",
+                  f"**Items queued for translation follow-up:** {actionable}",
+                  "",
+                  "`translation-coverage.jsonl` contains one machine-readable record "
+                  "per untranslated, unfinished, or incomplete-plural entry.",
+              ])
+          else:
+              lines.extend([
+                  "",
+                  "**Items queued for translation follow-up:** 0",
+              ])
+
+          markdown = "\n".join(lines) + "\n"
+          markdown_path.write_text(markdown, encoding="utf-8")
+
+          summary_path = Path(__import__("os").environ["GITHUB_STEP_SUMMARY"])
+          with summary_path.open("a", encoding="utf-8") as summary:
+              summary.write(markdown)
+
+          print(markdown)
+          print(f"Coverage queue contains {actionable} item(s).")
+          PY
+
+      - name: Upload translation coverage queue
+        if: always() && steps.translations.outputs.should_run == 'true'
+        continue-on-error: true
+        uses: actions/upload-artifact@v6
+        with:
+          name: translation-coverage-${{ github.run_id }}
+          path: |
+            translation-coverage.md
+            translation-coverage.jsonl
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: No translation validation required
+        if: steps.translations.outputs.should_run != 'true'
+        shell: bash
+        run: |
+          if [[ "${{ steps.translations.outputs.present }}" != "true" ]]; then
+            echo "Repository contains zero .ts files."
+            echo "Qt installation and lrelease validation skipped."
+          else
+            echo "No .ts translation paths changed."
+            echo "Qt installation and lrelease validation skipped."
+          fi
+
+          echo "Translation Validation succeeded without running lrelease."


### PR DESCRIPTION
## Summary

Adds a dedicated Translation Validation workflow for OpenToonz translation catalogs.

### Hard validation gate
- Always reports a stable `Translation Validation` result on pull requests targeting `main`.
- Avoids workflow-level path filters so the check cannot remain pending when no translation files changed.
- Detects `.ts` additions, modifications, deletions, renames, and copies using NUL-delimited `git diff --name-status -z` parsing.
- Explicitly skips Qt installation when the checked-out repository contains zero `.ts` files.
- Runs Qt 5 `lrelease` against every current translation catalog when translation paths change.
- Emits GitHub file/line annotations for `lrelease` errors when line/column data is available.
- Changes to this workflow force a full translation scan so the validation workflow tests itself.

### Non-blocking coverage report
- Reports untranslated, unfinished, and incomplete plural-form entries without failing the validation gate.
- Excludes obsolete/vanished messages from active coverage counts.
- Writes a Markdown job summary.
- Uploads a machine-readable `translation-coverage.jsonl` queue plus the Markdown report for later human review or future auto-translation processing.

## Why

PR #6960 upstream exposed a malformed Qt `numerus` translation that failed during `lrelease`. A focused translation gate catches this class of defect directly without requiring a full OpenToonz build, while the separate coverage report identifies translation work that should be followed up without blocking merges.

## Initial test

This PR changes the validation workflow itself, so the workflow is designed to force one full scan of the existing OT-Dev translation catalogs when the PR runs.