### PR TITLE
[Explore] Enhanced Savebox Controls

### DIFF
--- a/toonz/sources/include/toonz/fill.h
+++ b/toonz/sources/include/toonz/fill.h
@@ -45,6 +45,7 @@ public:
   bool m_defRegionWithPaint;
   bool m_usePrevailingReferFill;
   bool m_extendFill;
+  bool m_fillOnlySavebox;
 
   FillParameters()
       : m_styleId(0)
@@ -58,6 +59,7 @@ public:
       , m_palette(0)
       , m_prevailing(true)
       , m_extendFill(false)
+      , m_fillOnlySavebox(false)
       , m_defRegionWithPaint(true)
       , m_usePrevailingReferFill(false) {
     m_defRegionWithPaint     = DEF_REGION_WITH_PAINT;
@@ -75,6 +77,7 @@ public:
       , m_palette(params.m_palette)
       , m_prevailing(params.m_prevailing)
       , m_extendFill(params.m_extendFill)
+      , m_fillOnlySavebox(params.m_fillOnlySavebox)
       , m_defRegionWithPaint(params.m_defRegionWithPaint)
       , m_usePrevailingReferFill(params.m_usePrevailingReferFill) {}
 };

--- a/toonz/sources/tnztools/fillsaveboxcommands.h
+++ b/toonz/sources/tnztools/fillsaveboxcommands.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#ifndef FILL_SAVEBOX_COMMANDS_H
+#define FILL_SAVEBOX_COMMANDS_H
+
+class TTool;
+
+namespace FillSaveboxCommands {
+bool isEditMode(TTool *tool);
+void setEditMode(TTool *tool, bool enabled);
+bool fitToDrawing(TTool *tool);
+}  // namespace FillSaveboxCommands
+
+#endif  // FILL_SAVEBOX_COMMANDS_H

--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -83,6 +83,8 @@ TEnv::IntVar FillCloseGap("InknpaintFillCloseGap", 0);
 TEnv::IntVar FillReferFill("InknpaintFillReferFill", 0);
 TEnv::IntVar FillRange("InknpaintFillRange", 0);
 TEnv::IntVar FillExtend("InknpaintFillExtend", 0);
+// -1 means the Fill Tool has not established its own savebox state yet.
+TEnv::IntVar FillOnlySavebox("InknpaintFillOnlySavebox", -1);
 
 //-----------------------------------------------------------------------------
 
@@ -842,7 +844,7 @@ void fillAreaWithUndo(const TImageP &img, const TRaster32P &ref,
                       const TRectD &area, TStroke *stroke, bool onlyUnfilled,
                       std::wstring colorType, TXshSimpleLevel *sl,
                       const TFrameId &fid, int cs, bool autopaintLines,
-                      bool fillAllautoPaintLines) {
+                      bool fillAllautoPaintLines, bool fillOnlySavebox) {
   TRectD selArea = stroke ? stroke->getBBox().enlarge(1) : area;
   if (TToonzImageP ti = img) {
     // Expand savebox by 1 so rectfill of entire image does a single fill
@@ -866,14 +868,15 @@ void fillAreaWithUndo(const TImageP &img, const TRaster32P &ref,
 
     TPoint offs(0, 0);
     TRect rasSaveBox;
-    TRasterCM32P raux;
-    if (Preferences::instance()->getFillOnlySavebox()) {
+    TRasterCM32P raux = ti->getRaster();
+    if (fillOnlySavebox) {
       TRectD bbox = ti->getBBox();
-      rasSaveBox  = convert(bbox);
-      offs        = rasSaveBox.getP00();
-      raux        = ti->getRaster()->extract(rasSaveBox);
-    } else
-      raux = ti->getRaster();
+      if (!bbox.isEmpty()) {
+        rasSaveBox = convert(bbox);
+        offs       = rasSaveBox.getP00();
+        raux       = ti->getRaster()->extract(rasSaveBox);
+      }
+    }
 
     TRect auxStrokeBox = rasStrokeBox - offs;
     TRect auxBounds    = ras->getBounds();
@@ -1063,7 +1066,7 @@ void doRefFill(const TImageP &img, const TRaster32P &refImg, const TPointD &pos,
     TPoint offs(0, 0);
     TRasterCM32P ras = ti->getRaster();
 
-    if (Preferences::instance()->getFillOnlySavebox()) {
+    if (params.m_fillOnlySavebox) {
       TRectD bbox = ti->getBBox();
       if (!bbox.isEmpty()) {
         TRect ibbox = convert(bbox);
@@ -1122,8 +1125,8 @@ void doRefFill(const TImageP &img, const TRaster32P &refImg, const TPointD &pos,
           t->m_rasterBounds = t->m_rasterBounds + offs;
         }
       TUndoManager::manager()->add(new RasterFillUndo(
-          tileSet, params, sl, fid,
-          Preferences::instance()->getFillOnlySavebox(), refImg.getPointer()));
+          tileSet, params, sl, fid, params.m_fillOnlySavebox,
+          refImg.getPointer()));
     }
 
     // Instead of updateFrame:
@@ -1238,13 +1241,15 @@ class MultiAreaFiller final : public SequencePainter {
   TVectorImageP m_firstImage, m_lastImage;
   int m_styleIndex;
   bool m_autopaintLines;
+  bool m_fillOnlySavebox;
   RefImgTable m_refImgTable;
   bool m_fillAllautoPaintLines;
 
 public:
   MultiAreaFiller(RefImgTable refImgTable, const TRectD &firstRect,
                   const TRectD &lastRect, bool unfilledOnly,
-                  std::wstring colorType, int styleIndex, bool autopaintLines)
+                  std::wstring colorType, int styleIndex, bool autopaintLines,
+                  bool fillOnlySavebox)
       : m_firstRect(firstRect)
       , m_lastRect(lastRect)
       , m_unfilledOnly(unfilledOnly)
@@ -1253,6 +1258,7 @@ public:
       , m_lastImage()
       , m_styleIndex(styleIndex)
       , m_autopaintLines(autopaintLines)
+      , m_fillOnlySavebox(fillOnlySavebox)
       , m_refImgTable(std::move(refImgTable)) {}
 
   ~MultiAreaFiller() {
@@ -1263,13 +1269,14 @@ public:
   MultiAreaFiller(RefImgTable &refImgTable, TStroke *&firstStroke,
                   TStroke *&lastStroke, bool unfilledOnly,
                   std::wstring colorType, int styleIndex, bool autopaintLines,
-                  bool fillAllautoPaintLines)
+                  bool fillAllautoPaintLines, bool fillOnlySavebox)
       : m_firstRect()
       , m_lastRect()
       , m_unfilledOnly(unfilledOnly)
       , m_colorType(colorType)
       , m_styleIndex(styleIndex)
       , m_autopaintLines(autopaintLines)
+      , m_fillOnlySavebox(fillOnlySavebox)
       , m_refImgTable(std::move(refImgTable))
       , m_fillAllautoPaintLines(fillAllautoPaintLines) {
     firstStroke->addRef();
@@ -1289,18 +1296,18 @@ public:
       TRectD rect(p0.x, p0.y, p1.x, p1.y);
       fillAreaWithUndo(img, m_refImgTable[imgId], rect, 0, m_unfilledOnly,
                        m_colorType, sl, fid, m_styleIndex, m_autopaintLines,
-                       m_fillAllautoPaintLines);
+                       m_fillAllautoPaintLines, m_fillOnlySavebox);
     } else {
       if (t == 0)
         fillAreaWithUndo(img, m_refImgTable[imgId], TRectD(),
                          m_firstImage->getStroke(0), m_unfilledOnly,
                          m_colorType, sl, fid, m_styleIndex, m_autopaintLines,
-                         m_fillAllautoPaintLines);
+                         m_fillAllautoPaintLines, m_fillOnlySavebox);
       else if (t == 1)
         fillAreaWithUndo(img, m_refImgTable[imgId], TRectD(),
                          m_lastImage->getStroke(0), m_unfilledOnly, m_colorType,
                          sl, fid, m_styleIndex, m_autopaintLines,
-                         m_fillAllautoPaintLines);
+                         m_fillAllautoPaintLines, m_fillOnlySavebox);
       else
       // if(t>1)
       {
@@ -1315,7 +1322,7 @@ public:
         fillAreaWithUndo(img, m_refImgTable[imgId], TRectD(),
                          vi->getStroke(0) /*, imgloc*/, m_unfilledOnly,
                          m_colorType, sl, fid, m_styleIndex, m_autopaintLines,
-                         m_fillAllautoPaintLines);
+                         m_fillAllautoPaintLines, m_fillOnlySavebox);
       }
     }
   }
@@ -1412,6 +1419,7 @@ AreaFillTool::AreaFillTool(TTool *parent)
     , m_onion(false)
     , m_isLeftButtonPressed(false)
     , m_autopaintLines(true)
+    , m_fillOnlySavebox(false)
     , m_bckStyleId(0) {}
 
 void AreaFillTool::draw() {
@@ -1581,7 +1589,7 @@ void AreaFillTool::leftButtonDoubleClick(const TPointD &pos,
     if (m_firstFrameSelected && !slFidsPairs.empty()) {
       MultiAreaFiller filler(refImgTable, m_firstStroke, stroke, m_onlyUnfilled,
                              m_colorType, styleIndex, m_autopaintLines,
-                             m_paintAllAPs);
+                             m_paintAllAPs, m_fillOnlySavebox);
       filler.setSelectionUndo(new FillToolSelectionUndo(
           m_currCell.second, m_currCell.first, slFidsPairs[0].first,
           slFidsPairs[0].second));
@@ -1617,7 +1625,8 @@ void AreaFillTool::leftButtonDoubleClick(const TPointD &pos,
       fillAreaWithUndo(m_parent->getImage(true), refImgTable[imgId], TRectD(),
                        stroke, m_onlyUnfilled, m_colorType,
                        m_level.getPointer(), m_parent->getCurrentFid(),
-                       styleIndex, m_autopaintLines, m_paintAllAPs);
+                       styleIndex, m_autopaintLines, m_paintAllAPs,
+                       m_fillOnlySavebox);
       // fillAreaWithUndo should take on the stroke property
     }
     TTool *t = app->getCurrentTool()->getTool();
@@ -1672,7 +1681,7 @@ void AreaFillTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
       if (m_firstFrameSelected && !slFidsPairs.empty()) {
         MultiAreaFiller filler(refImgTable, m_firstRect, m_selectingRect,
                                m_onlyUnfilled, m_colorType, styleIndex,
-                               m_autopaintLines);
+                               m_autopaintLines, m_fillOnlySavebox);
         filler.setSelectionUndo(new FillToolSelectionUndo(
             m_currCell.second, m_currCell.first, slFidsPairs[0].first,
             slFidsPairs[0].second));
@@ -1708,7 +1717,8 @@ void AreaFillTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
         fillAreaWithUndo(m_parent->getImage(true), refImgTable[imgId],
                          m_selectingRect, 0, m_onlyUnfilled, m_colorType,
                          m_level.getPointer(), m_parent->getCurrentFid(),
-                         styleIndex, m_autopaintLines, m_paintAllAPs);
+                         styleIndex, m_autopaintLines, m_paintAllAPs,
+                         m_fillOnlySavebox);
       m_parent->invalidate();
       m_selectingRect.empty();
       TTool *t = app->getCurrentTool()->getTool();
@@ -1737,7 +1747,8 @@ void AreaFillTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
       if (m_firstFrameSelected) {
         MultiAreaFiller filler(refImgTable, m_firstStroke, stroke,
                                m_onlyUnfilled, m_colorType, styleIndex,
-                               m_autopaintLines, m_paintAllAPs);
+                               m_autopaintLines, m_paintAllAPs,
+                               m_fillOnlySavebox);
         filler.setSelectionUndo(new FillToolSelectionUndo(
             m_currCell.second, m_currCell.first, slFidsPairs[0].first,
             slFidsPairs[0].second));
@@ -1780,7 +1791,7 @@ void AreaFillTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
                          stroke /*, imageLocation*/, m_onlyUnfilled,
                          m_colorType, m_level.getPointer(),
                          m_parent->getCurrentFid(), styleIndex,
-                         m_autopaintLines, m_paintAllAPs);
+                         m_autopaintLines, m_paintAllAPs, m_fillOnlySavebox);
       delete stroke;
       TTool *t = app->getCurrentTool()->getTool();
       if (t) t->notifyImageChanged();
@@ -1805,13 +1816,15 @@ void AreaFillTool::onImageChanged() {
 /*-- Called when Type other than Normal is selected --*/
 bool AreaFillTool::onPropertyChanged(bool multi, bool onlyUnfilled, bool onion,
                                      Type type, std::wstring colorType,
-                                     bool autopaintLines) {
-  m_frameRange     = multi;
-  m_onlyUnfilled   = onlyUnfilled;
-  m_colorType      = colorType;
-  m_type           = type;
-  m_onion          = onion;
-  m_autopaintLines = autopaintLines;
+                                     bool autopaintLines,
+                                     bool fillOnlySavebox) {
+  m_frameRange      = multi;
+  m_onlyUnfilled    = onlyUnfilled;
+  m_colorType       = colorType;
+  m_type            = type;
+  m_onion           = onion;
+  m_autopaintLines  = autopaintLines;
+  m_fillOnlySavebox = fillOnlySavebox;
 
   if (m_frameRange) resetMulti();
 
@@ -1985,7 +1998,8 @@ FillTool::FillTool(int targetType)
     , m_firstTime(true)
     , m_autopaintLines("Autopaint Lines", true)
     , m_referFill("Refer Fill", false)
-    , m_extendFill("Extend Fill", true) {
+    , m_extendFill("Extend Fill", true)
+    , m_fillOnlySavebox("Savebox", false) {
   m_areaFillTool       = new AreaFillTool(this);
   m_normalLineFillTool = new NormalLineFillTool(this);
 
@@ -2016,6 +2030,7 @@ FillTool::FillTool(int targetType)
     m_maxGapDistance.setId("MaxGapDistance");
   }
   if (targetType == TTool::ToonzImage) {
+    m_prop.bind(m_fillOnlySavebox);
     m_prop.bind(m_autopaintLines);
     m_prop.bind(m_extendFill);
     m_prop.bind(m_gapCloseDistance);
@@ -2031,6 +2046,7 @@ FillTool::FillTool(int targetType)
   m_autopaintLines.setId("AutopaintLines");
   m_gapCloseDistance.setId("GapCloseDistance");
   m_extendFill.setId("ExtendFill");
+  m_fillOnlySavebox.setId("FillOnlySavebox");
 }
 //-----------------------------------------------------------------------------
 
@@ -2138,7 +2154,7 @@ void FillTool::computeRefImgsIfNeeded(const FillParameters &params) {
   }
 
   // Calculate every refImg
-  bool fillOnlySavebox = Preferences::instance()->getFillOnlySavebox();
+  bool fillOnlySavebox = m_fillOnlySavebox.getValue();
   //  TPointD cameraDpi =
   //      app->getCurrentScene()->getScene()->getCurrentCamera()->getDpi();
   for (auto [sl, fid] : m_slFidsPairs) {
@@ -2153,12 +2169,14 @@ void FillTool::computeRefImgsIfNeeded(const FillParameters &params) {
     auto imgId            = sl->getImageId(fid, 0);
     TPointD saveboxOffset = TPointD(0, 0);
     if (fillOnlySavebox) {
-      TRectD bbox    = ti->getBBox();
-      TRect ibbox    = convert(bbox);
-      TDimension res = ti->getSize();
-      saveboxOffset  = TPointD(res.lx / 2, res.ly / 2) - bbox.getP11() / 2 -
-                      bbox.getP00() / 2;
-      raux = ti->getRaster()->extract(ibbox);
+      TRectD bbox = ti->getBBox();
+      if (!bbox.isEmpty()) {
+        TRect ibbox    = convert(bbox);
+        TDimension res = ti->getSize();
+        saveboxOffset  = TPointD(res.lx / 2, res.ly / 2) - bbox.getP11() / 2 -
+                        bbox.getP00() / 2;
+        raux = ti->getRaster()->extract(ibbox);
+      }
     }
     TRaster32P ras(raux->getSize());
     ras->clear();
@@ -2202,6 +2220,7 @@ void FillTool::updateTranslation() {
   m_autopaintLines.setQStringName(tr("Autopaint Lines"));
   m_gapCloseDistance.setQStringName(tr("Gap Close Distance:"));
   m_extendFill.setQStringName(tr("Extend Fill"));
+  m_fillOnlySavebox.setQStringName(tr("Savebox"));
 }
 
 //-----------------------------------------------------------------------------
@@ -2215,9 +2234,10 @@ FillParameters FillTool::getFillParameters() const {
   params.m_emptyOnly = m_emptyOnly.getValue();
   params.m_segment   = m_segment.getValue();
   // RefFill is not controlled params
-  params.m_minFillDepth = (int)m_fillDepth.getValue().first;
-  params.m_maxFillDepth = (int)m_fillDepth.getValue().second;
-  params.m_extendFill   = m_extendFill.getValue();
+  params.m_minFillDepth    = (int)m_fillDepth.getValue().first;
+  params.m_maxFillDepth    = (int)m_fillDepth.getValue().second;
+  params.m_extendFill      = m_extendFill.getValue();
+  params.m_fillOnlySavebox = m_fillOnlySavebox.getValue();
   return params;
 }
 
@@ -2483,6 +2503,12 @@ bool FillTool::onPropertyChanged(std::string propertyName, bool addToUndo) {
   else if (propertyName == m_autopaintLines.getName()) {
     rectPropChangedflag = true;
   }
+  // Savebox
+  else if (propertyName == m_fillOnlySavebox.getName()) {
+    FillOnlySavebox     = m_fillOnlySavebox.getValue() ? 1 : 0;
+    rectPropChangedflag = true;
+    invalidate();
+  }
   // Gap Close Distance
   else if (propertyName == m_gapCloseDistance.getName()) {
     AutocloseDistance = m_gapCloseDistance.getValue();
@@ -2548,7 +2574,8 @@ bool FillTool::onPropertyChanged(std::string propertyName, bool addToUndo) {
 
     m_areaFillTool->onPropertyChanged(
         m_frameRange.getValue(), m_emptyOnly.getValue(), m_onion.getValue(),
-        type, m_colorType.getValue(), m_autopaintLines.getValue());
+        type, m_colorType.getValue(), m_autopaintLines.getValue(),
+        m_fillOnlySavebox.getValue());
   }
 
   return true;
@@ -2596,7 +2623,7 @@ void FillTool::onFrameSwitched() {
 //-----------------------------------------------------------------------------
 
 void FillTool::draw() {
-  if (Preferences::instance()->getFillOnlySavebox()) {
+  if (m_fillOnlySavebox.getValue()) {
     TToonzImageP ti = (TToonzImageP)getImage(false);
     if (ti) {
       TRectD bbox =
@@ -2747,6 +2774,10 @@ void FillTool::onActivate() {
         AutocloseDistance, AutocloseAngle, AutocloseOpacity,
         AutocloseIgnoreAutoPaint);
     m_extendFill.setValue(FillExtend ? 1 : 0);
+    if (FillOnlySavebox < 0)
+      FillOnlySavebox =
+          Preferences::instance()->getFillOnlySavebox() ? 1 : 0;
+    m_fillOnlySavebox.setValue(FillOnlySavebox ? 1 : 0);
     m_firstTime = false;
 
     if (m_fillType.getValue() != NORMALFILL) {
@@ -2764,7 +2795,8 @@ void FillTool::onActivate() {
 
       m_areaFillTool->onPropertyChanged(
           m_frameRange.getValue(), m_emptyOnly.getValue(), m_onion.getValue(),
-          type, m_colorType.getValue(), m_autopaintLines.getValue());
+          type, m_colorType.getValue(), m_autopaintLines.getValue(),
+          m_fillOnlySavebox.getValue());
     }
   }
 

--- a/toonz/sources/tnztools/filltool.cpp
+++ b/toonz/sources/tnztools/filltool.cpp
@@ -24,6 +24,8 @@
 #include "tproperty.h"
 #include "tenv.h"
 #include "tools/stylepicker.h"
+#include "setsaveboxtool.h"
+#include "fillsaveboxcommands.h"
 
 #include "toonz/tstageobject.h"
 #include "toonz/dpiscale.h"
@@ -89,6 +91,35 @@ TEnv::IntVar FillOnlySavebox("InknpaintFillOnlySavebox", -1);
 //-----------------------------------------------------------------------------
 
 namespace {
+
+class FitSaveboxUndo final : public TToolUndo {
+  TRect m_oldSavebox;
+  TRect m_newSavebox;
+
+  void apply(const TRect &savebox) const {
+    TToonzImageP image = m_level->getFrame(m_frameId, true);
+    if (!image) return;
+    image->setSavebox(savebox);
+    TTool::Application *app = TTool::getApplication();
+    if (app) app->getCurrentXsheet()->notifyXsheetChanged();
+    notifyImageChanged();
+  }
+
+public:
+  FitSaveboxUndo(const TRect &oldSavebox, const TRect &newSavebox,
+                 TXshSimpleLevel *level, const TFrameId &fid)
+      : TToolUndo(level, fid)
+      , m_oldSavebox(oldSavebox)
+      , m_newSavebox(newSavebox) {}
+
+  void undo() const override { apply(m_oldSavebox); }
+  void redo() const override { apply(m_newSavebox); }
+  int getSize() const override { return sizeof(*this); }
+  QString getToolName() override {
+    return QObject::tr("Fit Savebox to Drawing");
+  }
+  int getHistoryType() override { return HistoryType::FillTool; }
+};
 
 inline int vectorFill(const TVectorImageP &img, const std::wstring &type,
                       const TPointD &point, int style, bool emptyOnly = false) {
@@ -1999,9 +2030,12 @@ FillTool::FillTool(int targetType)
     , m_autopaintLines("Autopaint Lines", true)
     , m_referFill("Refer Fill", false)
     , m_extendFill("Extend Fill", true)
-    , m_fillOnlySavebox("Savebox", false) {
+    , m_fillOnlySavebox("Savebox", false)
+    , m_setSaveboxTool(nullptr)
+    , m_editSavebox(false) {
   m_areaFillTool       = new AreaFillTool(this);
   m_normalLineFillTool = new NormalLineFillTool(this);
+  if (targetType == TTool::ToonzImage) m_setSaveboxTool = new SetSaveboxTool(this);
 
   bind(targetType);
   m_prop.bind(m_fillType);
@@ -2050,7 +2084,67 @@ FillTool::FillTool(int targetType)
 }
 //-----------------------------------------------------------------------------
 
+void FillTool::setSaveboxEditMode(bool enabled) {
+  if (m_targetType != TTool::ToonzImage || !m_setSaveboxTool) enabled = false;
+  if (m_editSavebox == enabled) return;
+  m_editSavebox = enabled;
+  resetMulti(true);
+  invalidate();
+  if (getApplication() && getApplication()->getCurrentTool())
+    getApplication()->getCurrentTool()->notifyToolChanged();
+}
+
+//-----------------------------------------------------------------------------
+
+bool FillTool::fitSaveboxToDrawing() {
+  if (m_targetType != TTool::ToonzImage) return false;
+  TToonzImageP image = getImage(true);
+  if (!image || !image->getRaster()) return false;
+
+  TRect oldSavebox = image->getSavebox();
+  TRect fittedSavebox;
+  TRop::computeBBox(image->getRaster(), fittedSavebox);
+  if (oldSavebox == fittedSavebox) return false;
+
+  TTool::Application *app = getApplication();
+  TXshSimpleLevel *level =
+      app && app->getCurrentLevel() ? app->getCurrentLevel()->getSimpleLevel()
+                                    : nullptr;
+  if (!level) return false;
+
+  image->setSavebox(fittedSavebox);
+  level->setDirtyFlag(true);
+  TUndoManager::manager()->add(new FitSaveboxUndo(
+      oldSavebox, fittedSavebox, level, getCurrentFid()));
+  notifyImageChanged();
+  invalidate();
+  return true;
+}
+
+//-----------------------------------------------------------------------------
+
+namespace FillSaveboxCommands {
+bool isEditMode(TTool *tool) {
+  FillTool *fillTool = dynamic_cast<FillTool *>(tool);
+  return fillTool && fillTool->isSaveboxEditMode();
+}
+
+void setEditMode(TTool *tool, bool enabled) {
+  FillTool *fillTool = dynamic_cast<FillTool *>(tool);
+  if (fillTool) fillTool->setSaveboxEditMode(enabled);
+}
+
+bool fitToDrawing(TTool *tool) {
+  FillTool *fillTool = dynamic_cast<FillTool *>(tool);
+  return fillTool && fillTool->fitSaveboxToDrawing();
+}
+}  // namespace FillSaveboxCommands
+
+//-----------------------------------------------------------------------------
+
 int FillTool::getCursorId() const {
+  if (m_editSavebox && m_setSaveboxTool)
+    return m_setSaveboxTool->getCursorId(m_mousePos);
   int ret;
   if (m_colorType.getValue() == LINES)
     ret = ToolCursor::FillCursorL;
@@ -2244,6 +2338,10 @@ FillParameters FillTool::getFillParameters() const {
 //-----------------------------------------------------------------------------
 
 void FillTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
+  if (m_editSavebox && m_setSaveboxTool) {
+    m_setSaveboxTool->leftButtonDown(pos);
+    return;
+  }
   m_isAltPressed = e.isAltPressed();
   if (m_isAltPressed)
     Preferences::instance()->setValue(PreferencesItemId::DefRegionWithPaint,
@@ -2321,6 +2419,7 @@ void FillTool::leftButtonDown(const TPointD &pos, const TMouseEvent &e) {
 //-----------------------------------------------------------------------------
 
 void FillTool::leftButtonDoubleClick(const TPointD &pos, const TMouseEvent &e) {
+  if (m_editSavebox) return;
   if (m_fillType.getValue() != NORMALFILL) {
     buildFillInfo(getFillParameters());
     m_areaFillTool->leftButtonDoubleClick(pos, e);
@@ -2331,6 +2430,11 @@ void FillTool::leftButtonDoubleClick(const TPointD &pos, const TMouseEvent &e) {
 //-----------------------------------------------------------------------------
 
 void FillTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
+  if (m_editSavebox && m_setSaveboxTool) {
+    m_setSaveboxTool->leftButtonDrag(pos);
+    invalidate();
+    return;
+  }
   // Area mode
   if (m_fillType.getValue() != NORMALFILL) {
     m_areaFillTool->leftButtonDrag(pos, e);
@@ -2381,6 +2485,11 @@ void FillTool::leftButtonDrag(const TPointD &pos, const TMouseEvent &e) {
 //-----------------------------------------------------------------------------
 
 void FillTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
+  if (m_editSavebox && m_setSaveboxTool) {
+    m_setSaveboxTool->leftButtonUp(pos);
+    invalidate();
+    return;
+  }
   FillParameters params = getFillParameters();
   // Area mode
   if (m_fillType.getValue() != NORMALFILL) {
@@ -2418,6 +2527,10 @@ void FillTool::leftButtonUp(const TPointD &pos, const TMouseEvent &e) {
 
 bool FillTool::keyDown(QKeyEvent *e) {
   if (e && e->key() == Qt::Key_Escape) {
+    if (m_editSavebox) {
+      setSaveboxEditMode(false);
+      return true;
+    }
     if (m_fillType.getValue() != NORMALFILL)
       m_areaFillTool->resetMulti();
     else
@@ -2584,8 +2697,12 @@ bool FillTool::onPropertyChanged(std::string propertyName, bool addToUndo) {
 //-----------------------------------------------------------------------------
 
 void FillTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
-  if (m_fillType.getValue() != NORMALFILL) m_areaFillTool->mouseMove(pos, e);
   m_mousePos = pos;
+  if (m_editSavebox) {
+    invalidate();
+    return;
+  }
+  if (m_fillType.getValue() != NORMALFILL) m_areaFillTool->mouseMove(pos, e);
 }
 
 //-----------------------------------------------------------------------------
@@ -2623,6 +2740,10 @@ void FillTool::onFrameSwitched() {
 //-----------------------------------------------------------------------------
 
 void FillTool::draw() {
+  if (m_editSavebox && m_setSaveboxTool) {
+    m_setSaveboxTool->draw();
+    return;
+  }
   if (m_fillOnlySavebox.getValue()) {
     TToonzImageP ti = (TToonzImageP)getImage(false);
     if (ti) {
@@ -2836,6 +2957,7 @@ void FillTool::onActivate() {
 //-----------------------------------------------------------------------------
 
 void FillTool::onDeactivate() {
+  m_editSavebox = false;
   disconnect(TTool::m_application->getCurrentFrame(),
              &TFrameHandle::frameSwitched, this, &FillTool::onFrameSwitched);
   disconnect(TTool::m_application->getCurrentScene(),

--- a/toonz/sources/tnztools/filltool.h
+++ b/toonz/sources/tnztools/filltool.h
@@ -61,6 +61,7 @@ private:
   bool m_isLeftButtonPressed;
   bool m_paintAllAPs;
   bool m_autopaintLines;
+  bool m_fillOnlySavebox;
 
   int m_bckStyleId;
 
@@ -76,7 +77,8 @@ public:
   void leftButtonUp(const TPointD &pos, const TMouseEvent &e);
   void onImageChanged();
   bool onPropertyChanged(bool multi, bool onlyUnfilled, bool onion, Type type,
-                         std::wstring colorType, bool autopaintLines);
+                         std::wstring colorType, bool autopaintLines,
+                         bool fillOnlySavebox);
   void onActivate();
   void onEnter();
 };
@@ -121,6 +123,7 @@ class FillTool final : public QObject, public TTool {
   // disabled
   TBoolProperty m_autopaintLines;
   TBoolProperty m_extendFill;
+  TBoolProperty m_fillOnlySavebox;
 
   SlFidsPairs m_slFidsPairs;
   RefImgTable m_refImgTable;  // imageId

--- a/toonz/sources/tnztools/filltool.h
+++ b/toonz/sources/tnztools/filltool.h
@@ -24,6 +24,7 @@
 #define ALL L"Lines & Areas"
 
 class NormalLineFillTool;
+class SetSaveboxTool;
 typedef std::vector<std::pair<TXshSimpleLevel *, TFrameId>> SlFidsPairs;
 typedef std::map<std::string, TRaster32P> RefImgTable;
 
@@ -124,6 +125,8 @@ class FillTool final : public QObject, public TTool {
   TBoolProperty m_autopaintLines;
   TBoolProperty m_extendFill;
   TBoolProperty m_fillOnlySavebox;
+  SetSaveboxTool *m_setSaveboxTool;
+  bool m_editSavebox;
 
   SlFidsPairs m_slFidsPairs;
   RefImgTable m_refImgTable;  // imageId
@@ -141,6 +144,10 @@ public:
   TPropertyGroup *getProperties(int targetType) override { return &m_prop; }
   
   FillParameters getFillParameters() const;
+
+  bool isSaveboxEditMode() const { return m_editSavebox; }
+  void setSaveboxEditMode(bool enabled);
+  bool fitSaveboxToDrawing();
 
   void leftButtonDown(const TPointD &pos, const TMouseEvent &e) override;
   void leftButtonDrag(const TPointD &pos, const TMouseEvent &e) override;

--- a/toonz/sources/tnztools/tooloptions.cpp
+++ b/toonz/sources/tnztools/tooloptions.cpp
@@ -261,8 +261,20 @@ void ToolOptionControlBuilder::visit(TIntProperty *p) {
 //-----------------------------------------------------------------------------
 
 void ToolOptionControlBuilder::visit(TBoolProperty *p) {
-  ToolOptionCheckbox *control = new ToolOptionCheckbox(m_tool, p, m_toolHandle);
-  hLayout()->addWidget(control, 0);
+  ToolOptionControl *control;
+  QWidget *widget;
+  if (p->getId() == "FillOnlySavebox") {
+    ToolOptionSaveboxButton *saveboxControl =
+        new ToolOptionSaveboxButton(m_tool, p, m_toolHandle);
+    control = saveboxControl;
+    widget  = saveboxControl;
+  } else {
+    ToolOptionCheckbox *checkbox =
+        new ToolOptionCheckbox(m_tool, p, m_toolHandle);
+    control = checkbox;
+    widget  = checkbox;
+  }
+  hLayout()->addWidget(widget, 0);
 
   m_panel->addControl(control);
   hLayout()->addSpacing(5);

--- a/toonz/sources/tnztools/tooloptionscontrols.cpp
+++ b/toonz/sources/tnztools/tooloptionscontrols.cpp
@@ -23,6 +23,7 @@
 #include "tools/tool.h"
 #include "rasterselectiontool.h"
 #include "vectorselectiontool.h"
+#include "fillsaveboxcommands.h"
 // to enable the increase/decrease shortcuts while hiding the tool option
 #include "tools/toolhandle.h"
 // to enable shortcuts only when the viewer is focused
@@ -116,6 +117,72 @@ void ToolOptionCheckbox::nextCheckState() {
   QAbstractButton::nextCheckState();
   m_property->setValue(checkState() == Qt::Checked);
   notifyTool();
+}
+
+//=============================================================================
+// ToolOptionSaveboxButton
+
+ToolOptionSaveboxButton::ToolOptionSaveboxButton(
+    TTool *tool, TBoolProperty *property, ToolHandle *toolHandle, QWidget *parent)
+    : QToolButton(parent)
+    , ToolOptionControl(tool, property->getName(), toolHandle)
+    , m_property(property) {
+  setText(property->getQStringName());
+  setCheckable(true);
+  setAutoRaise(true);
+  setToolTip(tr("Savebox - Right-click for options"));
+  m_property->addListener(this);
+  updateStatus();
+}
+
+//-----------------------------------------------------------------------------
+
+void ToolOptionSaveboxButton::updateStatus() {
+  setText(m_property->getQStringName());
+  setChecked(m_property->getValue());
+}
+
+//-----------------------------------------------------------------------------
+
+void ToolOptionSaveboxButton::contextMenuEvent(QContextMenuEvent *event) {
+  QMenu menu(this);
+
+  QAction *limitAction = menu.addAction(tr("Limit Fill to Savebox"));
+  limitAction->setCheckable(true);
+  limitAction->setChecked(m_property->getValue());
+
+  QAction *editAction = menu.addAction(tr("Edit Savebox"));
+  editAction->setCheckable(true);
+  editAction->setChecked(FillSaveboxCommands::isEditMode(m_tool));
+
+  QAction *fitAction = menu.addAction(tr("Fit Savebox to Drawing"));
+
+  menu.addSeparator();
+
+  Preferences *preferences = Preferences::instance();
+  QAction *minimizeAction =
+      menu.addAction(tr("Minimize Savebox after Editing"));
+  minimizeAction->setCheckable(true);
+  minimizeAction->setChecked(preferences->isMinimizeSaveboxAfterEditing());
+
+  QAction *chosen = menu.exec(event->globalPos());
+  if (!chosen) return;
+
+  if (chosen == limitAction) {
+    m_property->setValue(!m_property->getValue());
+    notifyTool(false);
+    updateStatus();
+  } else if (chosen == editAction) {
+    FillSaveboxCommands::setEditMode(
+        m_tool, !FillSaveboxCommands::isEditMode(m_tool));
+  } else if (chosen == fitAction) {
+    FillSaveboxCommands::fitToDrawing(m_tool);
+  } else if (chosen == minimizeAction) {
+    preferences->setValue(minimizeSaveboxAfterEditing,
+                          !preferences->isMinimizeSaveboxAfterEditing());
+  }
+
+  if (m_toolHandle) m_toolHandle->notifyToolChanged();
 }
 
 //=============================================================================

--- a/toonz/sources/tnztools/tooloptionscontrols.h
+++ b/toonz/sources/tnztools/tooloptionscontrols.h
@@ -48,6 +48,7 @@
 #endif
 
 class TTool;
+class QContextMenuEvent;
 class TFrameHandle;
 class TObjectHandle;
 class TXsheetHandle;
@@ -101,6 +102,28 @@ public:
 
 protected:
   void nextCheckState() override;
+};
+
+//-----------------------------------------------------------------------------
+
+// Savebox is a feature group rather than a simple boolean tool option.
+// Keep its Fill-limit state in the existing TBoolProperty, while presenting a
+// compact toolbar indicator whose right-click menu exposes Savebox operations.
+class ToolOptionSaveboxButton final : public QToolButton,
+                                      public ToolOptionControl {
+protected:
+  TBoolProperty *m_property;
+
+public:
+  ToolOptionSaveboxButton(TTool *tool, TBoolProperty *property,
+                          ToolHandle *toolHandle = 0, QWidget *parent = 0);
+  void updateStatus() override;
+
+protected:
+  // The checked appearance is only an indicator. State changes live in the
+  // right-click menu so a normal left click cannot silently toggle Fill.
+  void nextCheckState() override {}
+  void contextMenuEvent(QContextMenuEvent *event) override;
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add Fill Tool **Savebox controls** for Toonz Raster levels while retaining the existing global Preferences behavior as the initial/default seed.

The implementation now treats Savebox as a small feature group rather than exposing a permanent checkbox in the Fill Tool options bar:
- show a compact **Savebox** toolbar indicator instead of the checkbox
- **right-click Savebox** to open the initial Savebox menu
- **Limit Fill to Savebox** is a checkable menu option backed by the Fill Tool's persisted `TEnv` state
- **Edit Savebox** reuses the existing `SetSaveboxTool` interaction while keeping the Fill Tool selected
- **Fit Savebox to Drawing** recomputes the current frame's Savebox from raster content and creates a dedicated undo record
- **Minimize Savebox after Editing** exposes the existing global preference from the same menu
- `Esc` exits Savebox edit mode
- the Savebox toolbar indicator reflects whether Fill limiting is active

The existing Fill behavior remains routed through the per-tool Savebox state for normal/reference fill, area fill, frame-range fill, undo/redo, reference-image generation, and the Savebox overlay. Empty Savebox still falls back to whole-image filling.

Shortcut bindings are deliberately deferred to the next step; the priority of this revision is establishing and testing the right-click Savebox menu and edit workflow.

## Attribution

This is a **partial port/adaptation from Tahoma2D**, based on `tahoma2d/tahoma2d@563c0227954294c32c53f64beafc7df8fd85afdd` ("Move TVL Savebox Limit Preference to toolbar option") by @manongjohn. The OpenToonz adaptation deliberately retains the existing global Fill preference as the first-use default rather than replacing it.

The original implementation commit includes the required attribution:

`Co-authored-by: manongjohn <manongjohn@users.noreply.github.com>`

## Testing focus

- Savebox appears as a toolbar indicator, not a checkbox
- right-click opens the Savebox menu
- Limit Fill to Savebox toggles Fill behavior and persists independently after first-use seeding
- Edit Savebox allows moving/resizing the current Savebox without switching to the Selection Tool
- Esc leaves Edit Savebox mode
- Fit Savebox to Drawing tightens the Savebox to current raster content and is undoable/redoable
- Minimize Savebox after Editing reflects and changes the existing preference
- click, drag, rectangular, freehand, polyline, frame-range, Refer Fill and Close Gap paths continue to respect Fill's Savebox state
- empty Savebox continues to fall back to whole-image behavior
- regression checks around prior Savebox/fill crash fixes

## Status

Implementation is staged on the branch. This remains a draft while CI and the focused visual/regression test pass run.