### PR TITLE
(WIP) Relax Animate Tool Handle Size

### DIFF
--- a/toonz/sources/toonzqt/intfield.cpp
+++ b/toonz/sources/toonzqt/intfield.cpp
@@ -11,6 +11,7 @@
 #include <QFocusEvent>
 #include <QPainter>
 #include <QPushButton>
+#include <QSignalBlocker>
 
 namespace {
 const int NonLinearSliderPrecision = 2;
@@ -347,9 +348,17 @@ void IntField::getRange(int &minValue, int &maxValue) {
 //-----------------------------------------------------------------------------
 
 void IntField::setRange(int minValue, int maxValue) {
-  m_lineEdit->setRange(minValue, m_isMaxRangeLimited
-                                     ? maxValue
-                                     : (std::numeric_limits<int>::max)());
+  // The Animate Tool handle-size preference intentionally keeps its slider in
+  // the common 100%-600% range, while permitting smaller values to be typed.
+  // Keep this narrowly scoped here while the WIP behavior is evaluated.
+  int lineEditMin = minValue;
+  if (minValue == 100 && maxValue == 600 && parent() &&
+      qstrcmp(parent()->metaObject()->className(), "PreferencesPopup") == 0)
+    lineEditMin = 1;
+
+  m_lineEdit->setRange(lineEditMin, m_isMaxRangeLimited
+                                        ? maxValue
+                                        : (std::numeric_limits<int>::max)());
   if (m_isLinearSlider)
     m_slider->setRange(minValue, maxValue);
   else
@@ -363,6 +372,9 @@ void IntField::setRange(int minValue, int maxValue) {
 void IntField::setValue(int value) {
   if (m_lineEdit->getValue() == value) return;
   m_lineEdit->setValue(value);
+  // A typed/programmatic value may intentionally sit outside the slider's
+  // suggested range. Do not let QSlider's clamping feed back into the editor.
+  const QSignalBlocker blocker(m_slider);
   m_slider->setSliderPosition(value2pos(value));
   m_roller->setValue((double)value);
 }
@@ -521,6 +533,8 @@ void IntField::onEditingFinished() {
   if ((pos2value(m_slider->value()) == value && m_slider->isVisible()) ||
       ((int)m_roller->getValue() == value && m_roller->isVisible()))
     return;
+  // Keep manually entered values outside the slider's suggested range intact.
+  const QSignalBlocker blocker(m_slider);
   m_slider->setValue(value2pos(value));
   m_roller->setValue((double)value);
   emit valueChanged(false);


### PR DESCRIPTION
## Overview

This WIP explores the first step proposed in response to OpenToonz Discussion #7077.

The Animate Tool Handle Size control keeps its normal slider range at **100%–600%**, while allowing a manually entered value down to **1%**.

This preserves the useful/common slider range instead of compressing it to 1%–600%, while still allowing users to make the Animate Tool handles much smaller when needed.

## Current behavior

- Slider range remains **100–600**.
- Direct numeric entry can use **1–600** for the Animate Tool Handle Size preference.
- A value below the slider minimum is preserved rather than being clamped back to 100 when the field is committed or restored.
- The stored preference continues to use the existing decimal scale (`100% = 1.0`).

The implementation also prevents programmatic synchronization of an `IntField` slider from feeding the slider's clamped endpoint back into a manually entered value. This is consistent with the existing Fill Holes precedent, where the numeric field may represent values outside the slider's suggested range.

## Scope

This PR intentionally does **not** add a zero value yet.

### Possible follow-up PR

If the smaller-handle behavior proves useful, a separate follow-up could consider allowing **0%** as an explicit **Hide Handles** state. That should be implemented deliberately in the Animate Tool drawing / hit-testing behavior rather than treating zero only as a mathematical scale value.

## Reference

- https://github.com/opentoonz/opentoonz/discussions/7077
