### PR TITLE
Harden undo history for rapid draw/undo workflows

### DIFF
--- a/toonz/sources/common/tcore/tundo.cpp
+++ b/toonz/sources/common/tcore/tundo.cpp
@@ -124,6 +124,7 @@ public:
   ~TUndoManagerImp() {}
 
   void add(TUndo *undo);
+  void discardRedoHistory();
 
 public:
   static struct ManagerPtr {
@@ -140,7 +141,6 @@ public:
 
 private:
   void doAdd(TUndo *undo);
-  void discardRedoHistory();
 };
 
 //=============================================================================
@@ -268,7 +268,7 @@ bool TUndoManager::undo() {
     if (!m_imp->m_skipped) break;
   }
 
-  m_imp->m_skipped   = false;
+  m_imp->m_skipped    = false;
   m_imp->m_inUndoRedo = false;
   return changed;
 }
@@ -292,7 +292,7 @@ bool TUndoManager::redo() {
     if (!m_imp->m_skipped) break;
   }
 
-  m_imp->m_skipped   = false;
+  m_imp->m_skipped    = false;
   m_imp->m_inUndoRedo = false;
   return changed;
 }

--- a/toonz/sources/common/tcore/tundo.cpp
+++ b/toonz/sources/common/tcore/tundo.cpp
@@ -111,12 +111,14 @@ struct TUndoManager::TUndoManagerImp {
   UndoList m_undoList;
   UndoListIterator m_current;
   bool m_skipped;
+  bool m_inUndoRedo;
   int m_undoMemorySize;  // in bytes
 
   std::vector<TUndoBlock *> m_blockStack;
 
 public:
-  TUndoManagerImp() : m_skipped(false), m_undoMemorySize(0) {
+  TUndoManagerImp()
+      : m_skipped(false), m_inUndoRedo(false), m_undoMemorySize(0) {
     m_current = m_undoList.end();
   }
   ~TUndoManagerImp() {}
@@ -138,6 +140,7 @@ public:
 
 private:
   void doAdd(TUndo *undo);
+  void discardRedoHistory();
 };
 
 //=============================================================================
@@ -179,11 +182,26 @@ void TUndoManager::TUndoManagerImp::add(TUndo *undo) {
 
 //-----------------------------------------------------------------------------
 
+void TUndoManager::TUndoManagerImp::discardRedoHistory() {
+  if (m_current == m_undoList.end()) return;
+
+  // Move the abandoned redo branch out of the live history before deleting it.
+  // Destructors for individual undo items may release sizeable drawing data or
+  // trigger other cleanup. Keeping the manager's iterator state consistent
+  // first makes rapid "draw -> undo -> draw" workflows less vulnerable to
+  // re-entrant observers seeing a half-pruned history list.
+  UndoList discarded;
+  discarded.insert(discarded.end(), m_current, m_undoList.end());
+  m_undoList.erase(m_current, m_undoList.end());
+  m_current = m_undoList.end();
+
+  std::for_each(discarded.begin(), discarded.end(), deleteUndo);
+}
+
+//-----------------------------------------------------------------------------
+
 void TUndoManager::TUndoManagerImp::doAdd(TUndo *undo) {
-  if (m_current != m_undoList.end()) {
-    std::for_each(m_current, m_undoList.end(), deleteUndo);
-    m_undoList.erase(m_current, m_undoList.end());
-  }
+  discardRedoHistory();
 
   int i, memorySize = 0, count = m_undoList.size();
   for (i = 0; i < count; i++) memorySize += m_undoList[i]->getSize();
@@ -207,10 +225,7 @@ void TUndoManager::TUndoManagerImp::doAdd(TUndo *undo) {
 //-----------------------------------------------------------------------------
 
 void TUndoManager::beginBlock() {
-  if (m_imp->m_current != m_imp->m_undoList.end()) {
-    std::for_each(m_imp->m_current, m_imp->m_undoList.end(), deleteUndo);
-    m_imp->m_undoList.erase(m_imp->m_current, m_imp->m_undoList.end());
-  }
+  m_imp->discardRedoHistory();
 
   TUndoBlock *undoBlock = new TUndoBlock;
   m_imp->m_blockStack.push_back(undoBlock);
@@ -238,38 +253,48 @@ void TUndoManager::endBlock() {
 
 bool TUndoManager::undo() {
   assert(m_imp->m_blockStack.empty());
-  UndoListIterator &it = m_imp->m_current;
-  if (it != m_imp->m_undoList.begin()) {
+  if (m_imp->m_inUndoRedo) return false;
+
+  m_imp->m_inUndoRedo = true;
+  bool changed        = false;
+
+  while (m_imp->m_current != m_imp->m_undoList.begin()) {
     m_imp->m_skipped = false;
-    --it;
-    (*it)->undo();
+    --m_imp->m_current;
+    (*m_imp->m_current)->undo();
+    changed = true;
     emit historyChanged();
-    if (m_imp->m_skipped) {
-      m_imp->m_skipped = false;
-      return undo();
-    }
-    return true;
-  } else
-    return false;
+
+    if (!m_imp->m_skipped) break;
+  }
+
+  m_imp->m_skipped   = false;
+  m_imp->m_inUndoRedo = false;
+  return changed;
 }
 
 //-----------------------------------------------------------------------------
 
 bool TUndoManager::redo() {
   assert(m_imp->m_blockStack.empty());
-  UndoListIterator &it = m_imp->m_current;
-  if (it != m_imp->m_undoList.end()) {
+  if (m_imp->m_inUndoRedo) return false;
+
+  m_imp->m_inUndoRedo = true;
+  bool changed        = false;
+
+  while (m_imp->m_current != m_imp->m_undoList.end()) {
     m_imp->m_skipped = false;
-    (*it)->redo();
-    ++it;
+    (*m_imp->m_current)->redo();
+    ++m_imp->m_current;
+    changed = true;
     emit historyChanged();
-    if (m_imp->m_skipped) {
-      m_imp->m_skipped = false;
-      return redo();
-    }
-    return true;
-  } else
-    return false;
+
+    if (!m_imp->m_skipped) break;
+  }
+
+  m_imp->m_skipped   = false;
+  m_imp->m_inUndoRedo = false;
+  return changed;
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose

Investigates and hardens a potential weak point exposed by opentoonz/opentoonz#6947: repeated drawing workflows where Undo is used continuously as an exploratory tool (draw a line, undo it, draw another line, undo it, and repeat).

The upstream crash report does **not** provide a trustworthy symbolized stack identifying `TUndoManager` as the crash site, so this PR should be treated as a focused experimental hardening change rather than a claimed definitive fix.

## What changes

- centralizes disposal of the abandoned redo branch when a new action follows an Undo;
- removes the redo items from the live history and restores `m_current` to a stable state **before** running their destructors;
- replaces recursive `skip()` handling in `undo()` / `redo()` with iteration;
- adds a guard against re-entering undo/redo while an undo or redo command is already executing.

## Why this path

A common drawing workflow can repeatedly exercise this sequence:

1. add drawing action;
2. Undo;
3. add replacement drawing action;
4. discard the now-invalid redo action(s);
5. repeat.

Previously, redo-history objects were deleted while the live undo container was still being mutated around `m_current`. This is normally fine when undo objects are passive, but drawing undos can own substantial image/stroke state and their cleanup is a poor place to expose half-mutated manager state to callbacks or observers.

Likewise, `skip()` previously implemented chained undo/redo operations by recursively calling `undo()` / `redo()`. Iteration is equivalent for normal behavior but avoids accumulating nested manager invocations in pathological history sequences.

## Scope / risk

This changes only generic undo-history bookkeeping. It does not alter brush rendering, stroke generation, autosave, scene saving, or the public undo API.

Because undo is foundational, this is intentionally a **draft** until CI and deliberate stress testing are complete.

## Suggested testing

In addition to normal Undo / Redo and History panel checks:

- repeatedly draw one stroke and Undo it hundreds of times;
- alternate `draw -> undo -> draw replacement` rapidly so every new stroke invalidates a redo branch;
- repeat with raster, Toonz Raster, and vector drawing where available;
- test with the History panel both open and closed;
- test with autosave enabled and disabled;
- fill the undo history near its configured memory limit;
- exercise multi-step undo/redo and operations that use `TUndoManager::skip()`;
- confirm that beginning an undo block after undoing correctly discards the redo branch.

## Reference

Upstream: https://github.com/opentoonz/opentoonz/issues/6947
