### PR TITLE
Fix loading Adam7-interlaced PNG images

### DIFF
--- a/tests/data/png/issue_242_repro.md
+++ b/tests/data/png/issue_242_repro.md
@@ -1,0 +1,20 @@
+# Issue #242 indexed PNG investigation
+
+This branch is for investigating upstream OpenToonz issue [#242](https://github.com/opentoonz/opentoonz/issues/242), where 8-bit indexed/paletted PNG images have historically loaded with corrupted/glitchy output or, in some variants, crashed.
+
+## Current observations
+
+- Upstream issue #242 is still open and was reopened.
+- The historical diagnosis points at the native PNG reader and specifically palette expansion / metadata after libpng transforms.
+- The current `tiio_png.cpp` already calls `png_set_palette_to_rgb()`, `png_set_tRNS_to_alpha()` when applicable, `png_read_update_info()`, then refreshes `m_channels` and `m_rowBytes`.
+- A user-supplied sky image reported to reproduce the problem visually should be tested in the actual OpenToonz import path on Windows, Linux and macOS.
+- The copy supplied in ChatGPT decoded as a normal RGBA PNG rather than palette mode, so the original indexed source or a freshly generated palette-preserving equivalent is needed for a precise regression fixture.
+
+## Investigation plan
+
+1. Reproduce with an actual `PNG_COLOR_TYPE_PALETTE` file (8-bit indexed) with and without `tRNS` transparency.
+2. Compare native OpenToonz PNG import against a reference decoder.
+3. Verify `m_bit_depth`, `m_color_type`, `m_channels`, `m_rowBytes`, `m_info.m_bitsPerSample`, and `m_info.m_samplePerPixel` before and after `png_read_update_info()`.
+4. Check whether `png_set_filler(..., 0xFF, PNG_FILLER_AFTER)` combined with `png_set_tRNS_to_alpha()` produces an invalid transform sequence for paletted PNGs carrying `tRNS`.
+5. Add a regression test/fixture once the exact failing palette encoding is confirmed.
+6. Keep the fix limited to PNG decoding unless evidence shows a broader raster import assumption.

--- a/toonz/sources/image/png/tiio_png.cpp
+++ b/toonz/sources/image/png/tiio_png.cpp
@@ -83,6 +83,7 @@ class PngReader final : public Tiio::Reader {
   int m_y;
   bool m_is16bitEnabled;
   std::unique_ptr<unsigned char[]> m_rowBuffer;
+  std::vector<unsigned char> m_imageBuffer;
   int m_canDelete;
   int m_channels;
   int m_rowBytes;
@@ -246,7 +247,7 @@ public:
 #error "unknown channel order"
 #endif
 
-    // Handle interlacing if present - let libpng handle it
+    // Register libpng's Adam7 pass handling before updating output info.
     if (m_interlace_type == PNG_INTERLACE_ADAM7) {
       png_set_interlace_handling(m_png_ptr);
     }
@@ -259,6 +260,7 @@ public:
     m_rowBytes = png_get_rowbytes(m_png_ptr, m_info_ptr);
     png_get_IHDR(m_png_ptr, m_info_ptr, &lx, &ly, &m_bit_depth, &m_color_type,
                  &m_interlace_type, &m_compression_type, &m_filter_type);
+    m_info.m_bitsPerSample = m_bit_depth;
     m_info.m_samplePerPixel = m_channels;
 
     // Validate dimensions
@@ -270,6 +272,23 @@ public:
     m_rowBuffer.reset(new unsigned char[m_rowBytes]);
     if (!m_rowBuffer) {
       throw TException("Memory allocation failed for row buffer");
+    }
+
+    // Adam7 PNG data is stored pass-by-pass, not row-by-row. The Tiio reader
+    // API asks for completed rows sequentially, so reading one libpng row per
+    // readLine() returns only the current Adam7 pass and produces the familiar
+    // sparse/glitchy image. Decode interlaced PNGs completely here, then serve
+    // completed rows from the cached image.
+    if (m_interlace_type == PNG_INTERLACE_ADAM7) {
+      const size_t imageBytes =
+          static_cast<size_t>(m_rowBytes) * static_cast<size_t>(m_info.m_ly);
+      m_imageBuffer.resize(imageBytes);
+
+      std::vector<png_bytep> rows(m_info.m_ly);
+      for (int y = 0; y < m_info.m_ly; ++y) {
+        rows[y] = m_imageBuffer.data() + static_cast<size_t>(y) * m_rowBytes;
+      }
+      png_read_image(m_png_ptr, rows.data());
     }
   }
 
@@ -300,7 +319,13 @@ public:
       return;
     }
 
-    png_read_row(m_png_ptr, m_rowBuffer.get(), nullptr);
+    if (!m_imageBuffer.empty()) {
+      memcpy(m_rowBuffer.get(),
+             m_imageBuffer.data() + static_cast<size_t>(m_y) * m_rowBytes,
+             m_rowBytes);
+    } else {
+      png_read_row(m_png_ptr, m_rowBuffer.get(), nullptr);
+    }
     writeRow(buffer, x0, x1);
     m_y++;
   }
@@ -331,7 +356,13 @@ public:
       return;
     }
 
-    png_read_row(m_png_ptr, m_rowBuffer.get(), nullptr);
+    if (!m_imageBuffer.empty()) {
+      memcpy(m_rowBuffer.get(),
+             m_imageBuffer.data() + static_cast<size_t>(m_y) * m_rowBytes,
+             m_rowBytes);
+    } else {
+      png_read_row(m_png_ptr, m_rowBuffer.get(), nullptr);
+    }
     writeRow(buffer, x0, x1);
     m_y++;
   }
@@ -342,6 +373,12 @@ public:
     int skipped = 0;
     for (int i = 0; i < lineCount; ++i) {
       if (m_y >= m_info.m_ly) break;
+
+      if (!m_imageBuffer.empty()) {
+        m_y++;
+        skipped++;
+        continue;
+      }
 
       if (setjmp(png_jmpbuf(m_png_ptr))) {
         break;  // Stop on error


### PR DESCRIPTION
## Purpose

Fix the long-standing PNG loading defect investigated through upstream OpenToonz issue [#242](https://github.com/opentoonz/opentoonz/issues/242), historically reported as **PNG8 files show glitchy image**.

## Reproduction / diagnosis

The palette-to-RGB transform itself works correctly with libpng for normal non-interlaced indexed PNGs, including palette PNGs with `tRNS` transparency.

The underlying defect is the native PNG reader's handling of **Adam7-interlaced PNGs**. `PngReader` called `png_set_interlace_handling()`, but the Tiio interface continued to consume exactly one `png_read_row()` per requested image row. Adam7 data is stored pass-by-pass, so a single sequential pass through the rows returns incomplete pass data rather than completed image rows. The resulting sparse/banded/glitchy output matches the historical symptom.

A controlled 8-bit indexed Adam7 PNG reproduced the failure outside OpenToonz by exercising the same libpng call sequence: the first requested row contained only the pixels supplied by the current Adam7 pass, with the remaining positions unset.

## Fix

The reader now:

- registers Adam7 interlace handling before `png_read_update_info()`;
- fully decodes Adam7 images with `png_read_image()` into an internal cache;
- serves completed cached rows through the existing Tiio `readLine()` interface;
- makes `skipLines()` advance through cached interlaced data without consuming libpng rows;
- refreshes `m_info.m_bitsPerSample` after libpng transformations, alongside `m_samplePerPixel`.

Non-interlaced PNGs continue to use the existing streaming row path.

## Validation

The originally reported sky PNG that exhibited the visible corruption has now been tested in a build containing this change and **loads correctly in OpenToonz without the previous glitching**. This provides direct real-world confirmation of the fix for the reported failure.

Remaining validation:

- Complete Windows/Linux/macOS CI.
- Test indexed PNGs with and without `tRNS` transparency.
- Test non-interlaced indexed PNGs to confirm no regression.
- Test additional Adam7 truecolor/RGBA PNGs, since the underlying defect is interlace handling rather than palette conversion itself.
- Add a compact regression fixture/test if a suitable PNG reader test location is identified.

Upstream reference: opentoonz/opentoonz#242