### PR TITLE
Check clang-format on changed PR source files

### DIFF
--- a/.github/workflows/workflow_clang_format.yml
+++ b/.github/workflows/workflow_clang_format.yml
@@ -1,0 +1,63 @@
+name: clang-format Check
+
+on:
+  pull_request:
+    paths:
+      - "toonz/sources/**/*.c"
+      - "toonz/sources/**/*.cc"
+      - "toonz/sources/**/*.cpp"
+      - "toonz/sources/**/*.cxx"
+      - "toonz/sources/**/*.h"
+      - "toonz/sources/**/*.hh"
+      - "toonz/sources/**/*.hpp"
+      - "toonz/sources/**/*.hxx"
+      - "toonz/sources/.clang-format"
+      - ".github/workflows/workflow_clang_format.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format-14
+
+      - name: Check formatting of changed C/C++ files
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          files=()
+          while IFS= read -r -d '' file; do
+            case "$file" in
+              toonz/sources/*.c|toonz/sources/*.cc|toonz/sources/*.cpp|toonz/sources/*.cxx|\
+              toonz/sources/*.h|toonz/sources/*.hh|toonz/sources/*.hpp|toonz/sources/*.hxx)
+                files+=("$file")
+                ;;
+            esac
+          done < <(
+            git diff --name-only --diff-filter=ACMR -z \
+              "$BASE_SHA" "$HEAD_SHA"
+          )
+
+          if (( ${#files[@]} == 0 )); then
+            echo "No changed C/C++ files to check."
+            exit 0
+          fi
+
+          printf 'Checking %s\n' "${files[@]}"
+          clang-format-14 --dry-run --Werror -style=file "${files[@]}"


### PR DESCRIPTION
Staging implementation intended to supersede the implementation approach in opentoonz/opentoonz#5615.

OpenToonz already keeps its authoritative clang-format configuration at `toonz/sources/.clang-format`, and the existing beautification scripts operate on files changed relative to the base branch. This proposal keeps that structure intact and adds CI verification that follows the same changed-files principle.

The workflow:
- runs only when relevant C/C++ source, `.clang-format`, or the lint workflow itself changes;
- checks only C/C++ files changed by the pull request;
- ignores deleted files;
- uses the existing `toonz/sources/.clang-format` through clang-format's normal `-style=file` lookup;
- verifies formatting with `--dry-run --Werror` rather than modifying contributor branches;
- grants only `contents: read` permission.

This avoids failing a pull request because unrelated legacy files elsewhere in the repository do not conform to current formatting rules.

After validation here, this branch is intended to be submitted upstream as the replacement implementation. The older upstream PR #5615 is closed as superceded with recommendation to open new report/PR where appropriate.