### PR TITLE
Stage full CI after draft exploration

### DIFF
--- a/.github/workflows/workflow_linux.yml
+++ b/.github/workflows/workflow_linux.yml
@@ -28,6 +28,9 @@ on:
       - '.github/workflows/workflow_linux.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   Ubuntu:
     # Keep exploratory draft PRs fast. Full CI starts when the PR is promoted,

--- a/.github/workflows/workflow_linux.yml
+++ b/.github/workflows/workflow_linux.yml
@@ -6,6 +6,8 @@ concurrency:
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '**/*'                   # Include all files in the repository
       - '!appveyor.yml'          # Ignore changes in AppVeyor
@@ -14,6 +16,9 @@ on:
       - '!**/.github/**'         # Exclude everything in .github folder
       - '.github/workflows/workflow_linux.yml'  # Include Linux workflow file
   pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
     paths:
       - '**/*'
       - '!appveyor.yml'
@@ -21,9 +26,16 @@ on:
       - '!doc/**'
       - '!**/.github/**'
       - '.github/workflows/workflow_linux.yml'
+  workflow_dispatch:
 
 jobs:
   Ubuntu:
+    # Keep exploratory draft PRs fast. Full CI starts when the PR is promoted,
+    # explicitly labelled ci:full, manually dispatched, or merged to main.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full')
     # Build on the oldest supported LTS: glibc/libstdc++ symbol versioning is
     # backward compatible only, so an AppImage built on 24.04 requires
     # GLIBC_2.38 / GLIBCXX_3.4.32 and will not start on 22.04 (see #7001).
@@ -128,6 +140,12 @@ jobs:
   # Compile-only: catches Fedora-specific breakage (package renames, newer
   # GCC/Qt) that the Ubuntu job cannot. Deliberately builds no AppImage.
   Fedora:
+    # Keep exploratory draft PRs fast. Full CI starts when the PR is promoted,
+    # explicitly labelled ci:full, manually dispatched, or merged to main.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full')
     runs-on: ubuntu-latest
     container:
       image: fedora:latest

--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -6,14 +6,19 @@ concurrency:
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '**/*'                                  # Include all files in the repository
       - '!appveyor.yml'                         # Ignore changes in AppVeyor
       - '!README.md'                            # Exclude README
       - '!doc/**'                               # Exclude documentation
       - '!**/.github/**'                        # Exclude everything in .github folder
-      - '.github/workflows/workflow_macos.yml'  # Include MacOs workflow file
+      - '.github/workflows/workflow_macos.yml'  # Include macOS workflow file
   pull_request:
+    branches:
+      - main
+    types: [opened, synchronize, reopened, ready_for_review, labeled]
     paths:
       - '**/*'
       - '!appveyor.yml'
@@ -21,9 +26,16 @@ on:
       - '!doc/**'
       - '!**/.github/**'
       - '.github/workflows/workflow_macos.yml'
+  workflow_dispatch:
 
 jobs:
   macOS:
+    # Keep exploratory draft PRs fast. Full CI starts when the PR is promoted,
+    # explicitly labelled ci:full, manually dispatched, or merged to main.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.draft == false ||
+      contains(github.event.pull_request.labels.*.name, 'ci:full')
     timeout-minutes: 180 # Stop job if it exceeds expected build time
     # GHA are sunsetting support for macOS 13 (Intel & Apple Silicon/arm) & will be fully unsupported on (December 4th 2025),
     # See: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/ & https://github.com/actions/runner-images/issues/13046

--- a/.github/workflows/workflow_macos.yml
+++ b/.github/workflows/workflow_macos.yml
@@ -28,6 +28,9 @@ on:
       - '.github/workflows/workflow_macos.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   macOS:
     # Keep exploratory draft PRs fast. Full CI starts when the PR is promoted,

--- a/.github/workflows/workflow_windows.yml
+++ b/.github/workflows/workflow_windows.yml
@@ -27,6 +27,9 @@ on:
       - '.github/workflows/workflow_windows.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   Windows:
     runs-on: windows-2025

--- a/.github/workflows/workflow_windows.yml
+++ b/.github/workflows/workflow_windows.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   push:
     branches:
-      - master  # Specify branches where the workflow should run
+      - main
     paths:
       - '**/*'                                    # Include all files in the repository
       - '!appveyor.yml'                           # Ignore changes in AppVeyor
@@ -16,6 +16,8 @@ on:
       - '!**/.github/**'                          # Exclude everything in .github folder
       - '.github/workflows/workflow_windows.yml'  # Include Windows workflow file
   pull_request:
+    branches:
+      - main
     paths:
       - '**/*'
       - '!appveyor.yml'
@@ -23,6 +25,7 @@ on:
       - '!doc/**'
       - '!**/.github/**'
       - '.github/workflows/workflow_windows.yml'
+  workflow_dispatch:
 
 jobs:
   Windows:


### PR DESCRIPTION
## Summary

Reduces duplicate and premature CI work during OT-Dev exploration while preserving a deliberate full-platform gate.

- Linux and macOS no longer run for feature-branch `push` events; pushes to `main` still receive full-platform confirmation.
- Draft pull requests skip the Linux GCC/Clang, Fedora and macOS build jobs.
- Marking a PR ready for review starts full CI.
- A draft can explicitly request full CI with the `ci:full` label.
- Linux, macOS and Windows workflows can be run manually with `workflow_dispatch`.
- Windows continues to run on draft PRs for early feedback.
- The stale Windows push target is corrected from `master` to OT-Dev `main`.

## Intended progression

| Stage | CI |
| --- | --- |
| Draft OT-Dev PR | Windows |
| Ready for review or `ci:full` | Windows + Linux GCC/Clang + Fedora + macOS |
| Push/merge to `main` | Full platform matrix |
| Manual investigation | Selected workflow through `workflow_dispatch` |

## Why

The existing Linux and macOS workflows react to both every feature-branch push and the corresponding pull request event. That duplicates expensive builds for the same commit. Full cross-platform coverage remains important, but it is more useful after an experiment is promoted beyond its initial draft stage.

## Validation

- Parsed all three edited workflow files as YAML.
- Verified Linux has draft gates on both Ubuntu and Fedora jobs.
- Verified macOS has a draft gate.
- Verified Windows has no draft gate.
- Verified all three push triggers target `main`, not `master`.
- Verified the commit changes only the three platform workflow files.

## Boundary

OT-Dev CI policy only. This PR targets `OpenAnimationLibrary/opentoonz-dev:main` and does not alter or propose changes to upstream `opentoonz/opentoonz:master`.
